### PR TITLE
Bug Fixes + Setting up System Health Status Card For Easy Debug

### DIFF
--- a/backend/src/core/backtest/backtestEngine.ts
+++ b/backend/src/core/backtest/backtestEngine.ts
@@ -28,6 +28,7 @@ import { newId } from "../../utils/ids";
 import type { BacktestConfig, BacktestResult } from "../../types/backtest";
 import type { PortfolioSnapshot } from "../../types/portfolio";
 import type { IStrategy } from "../../strategies/base/strategy";
+import type { Fill } from "../../types/orders";
 
 export class BacktestEngine {
   private readonly loader = new BacktestLoader();
@@ -115,6 +116,8 @@ export class BacktestEngine {
     const finalPortfolio = portfolioState.getSnapshot();
     const completedAt = nowMs();
 
+    const fills = orderState.getAllOrders().flatMap((o) => o.fills);
+
     const result: BacktestResult = {
       id: config.id,
       config,
@@ -122,10 +125,10 @@ export class BacktestEngine {
       startedAt,
       completedAt,
       finalPortfolio,
-      metrics: this._computeMetrics(equityCurve, config.initialCapital, startedAt, completedAt),
+      metrics: this._computeMetrics(equityCurve, fills, config.initialCapital, startedAt, completedAt),
       equityCurve,
       orders: orderState.getAllOrders(),
-      fills: orderState.getAllOrders().flatMap((o) => o.fills),
+      fills,
       eventCount: bars.length,
     };
 
@@ -144,19 +147,46 @@ export class BacktestEngine {
 
   private _computeMetrics(
     equityCurve: PortfolioSnapshot[],
+    fills: Fill[],
     initialCapital: number,
     periodStart: number,
     periodEnd: number,
   ) {
+    // Compute trade-level metrics by pairing buy+sell fills per symbol
+    const pnlPerTrade: number[] = [];
+    const buyMap = new Map<string, Fill[]>();
+
+    for (const fill of fills) {
+      if (fill.side === "buy") {
+        const existing = buyMap.get(fill.symbol) ?? [];
+        existing.push(fill);
+        buyMap.set(fill.symbol, existing);
+      } else {
+        const buys = buyMap.get(fill.symbol);
+        if (buys && buys.length > 0) {
+          const matchedBuy = buys.shift()!;
+          const pnl = (fill.price - matchedBuy.price) * fill.qty - fill.commission - matchedBuy.commission;
+          pnlPerTrade.push(pnl);
+        }
+      }
+    }
+
+    const totalTrades = pnlPerTrade.length;
+    const wins = pnlPerTrade.filter((p) => p > 0);
+    const losses = pnlPerTrade.filter((p) => p <= 0);
+    const winRate = totalTrades > 0 ? wins.length / totalTrades : 0;
+    const avgWin = wins.length > 0 ? wins.reduce((a, b) => a + b, 0) / wins.length : 0;
+    const avgLoss = losses.length > 0 ? losses.reduce((a, b) => a + b, 0) / losses.length : 0;
+
     if (equityCurve.length === 0) {
       return {
         totalReturn: 0,
         totalReturnPct: 0,
         maxDrawdown: 0,
-        winRate: 0,
-        totalTrades: 0,
-        avgWin: 0,
-        avgLoss: 0,
+        winRate,
+        totalTrades,
+        avgWin,
+        avgLoss,
         periodStart,
         periodEnd,
       };
@@ -179,10 +209,10 @@ export class BacktestEngine {
       totalReturn,
       totalReturnPct,
       maxDrawdown,
-      winRate: 0, // Placeholder — computed from fills in a real impl
-      totalTrades: 0,
-      avgWin: 0,
-      avgLoss: 0,
+      winRate,
+      totalTrades,
+      avgWin,
+      avgLoss,
       periodStart,
       periodEnd,
     };

--- a/backend/src/strategies/pairs/pairsStrategy.ts
+++ b/backend/src/strategies/pairs/pairsStrategy.ts
@@ -74,6 +74,7 @@ export class PairsStrategy extends BaseStrategy {
       : s2.latestTrade?.price ?? null;
 
     if (price1 === null || price2 === null) return null;
+    this.state.latestLeg1Price = price1;
 
     // Update hedge ratio if using rolling OLS (placeholder — uses fixed for now)
     const hedgeRatio = this._getHedgeRatio(price1, price2);
@@ -271,9 +272,9 @@ export class PairsStrategy extends BaseStrategy {
   }
 
   private _computeQty(): number {
-    // Placeholder: compute share quantity from tradeNotionalUsd and latest price
-    // In a real implementation, divide tradeNotionalUsd by current leg1 price
-    return 1;
+    const price = this.state.latestLeg1Price;
+    if (!price || price <= 0) return 0;
+    return Math.floor(this.pairsConfig.tradeNotionalUsd / price);
   }
 
   private _initState(): PairsInternalState {
@@ -287,6 +288,7 @@ export class PairsStrategy extends BaseStrategy {
       completedTrades: 0,
       cooldownActive: false,
       cooldownExpiresAt: null,
+      latestLeg1Price: null,
     };
   }
 }

--- a/backend/src/strategies/pairs/pairsTypes.ts
+++ b/backend/src/strategies/pairs/pairsTypes.ts
@@ -132,6 +132,8 @@ export interface PairsInternalState {
   cooldownActive: boolean;
   /** When the cooldown expires (Unix ms) */
   cooldownExpiresAt: EpochMs | null;
+  /** Most recent leg1 price used for position sizing */
+  latestLeg1Price: number | null;
 }
 
 // ------------------------------------------------------------------

--- a/backtest_setup.md
+++ b/backtest_setup.md
@@ -1,0 +1,354 @@
+# Issue #9 — Backtest Pipeline End-to-End
+
+Complete the steps below in order. Each section is a hard blocker for the ones that follow it.
+
+---
+
+## Part 1 — Environment Setup
+
+### 1. Install dependencies
+
+```bash
+cd backend
+npm install
+```
+
+### 2. Create the backend `.env` file
+
+```bash
+cp .env.example .env
+```
+
+Open `backend/.env` and fill in the following values. Leave everything else at its default.
+
+```
+ALPACA_API_KEY=<your paper trading key>
+ALPACA_API_SECRET=<your paper trading secret>
+ALPACA_TRADING_MODE=paper
+
+SUPABASE_URL=https://<your-project-id>.supabase.co
+SUPABASE_ANON_KEY=<anon public key>
+SUPABASE_SERVICE_ROLE_KEY=<service_role key>
+DATABASE_URL=postgresql://postgres:<password>@db.<your-project-id>.supabase.co:5432/postgres
+```
+
+**Where to find these values:**
+
+- **Alpaca keys** — log in to alpaca.markets → Paper Trading → API Keys → generate a new key pair
+- **Supabase keys** — Supabase dashboard → Project Settings → API. Copy the Project URL, `anon public` key, and `service_role` key. The `DATABASE_URL` password is the one set when creating the project.
+
+> The `SERVICE_ROLE_KEY` bypasses Row Level Security. Never commit `.env` to git — it is already in `.gitignore`.
+
+### 3. Resolve the DI wiring blocker
+
+The issue description flags a "DI wiring issue" as a prerequisite. Here is what it actually means and how it is resolved:
+
+`config/env.ts` calls `require("SUPABASE_URL")`, `require("ALPACA_API_KEY")`, etc. at **import time** — not lazily. This means the server process crashes immediately at startup with `Missing required environment variable: ...` if any of those keys are absent. The backtest controller, CLI entry point, and Supabase client all depend on this module loading cleanly.
+
+**The blocker is resolved entirely by completing Step 2 above.** No code changes are needed. Once `.env` is filled in, the server starts, the Supabase client initializes on its first call, and `POST /api/backtests/run` becomes reachable. The backtest controller creates its own isolated `BacktestEngine` per request and does not need the live `Orchestrator`.
+
+### 4. Create the Supabase `backtest_results` table
+
+Open the Supabase dashboard → SQL Editor → New query. Paste and run:
+
+```sql
+create table if not exists backtest_results (
+  id              uuid         primary key,
+  config          jsonb        not null,
+  status          text         not null,
+  started_at      bigint       not null,
+  completed_at    bigint,
+  error_message   text,
+  final_portfolio jsonb        not null,
+  metrics         jsonb        not null,
+  equity_curve    jsonb        not null,
+  orders          jsonb        not null,
+  fills           jsonb        not null,
+  event_count     integer      not null,
+  inserted_at     timestamptz  not null default now()
+);
+```
+
+Verify the table appears under Table Editor before continuing.
+
+---
+
+## Part 2 — Task 1: Smoke Test the Bar Loader
+
+Run the backtest CLI entry point. This fetches 1-min bars for SPY and QQQ over all of 2023.
+
+```bash
+npm run dev:backtest
+```
+
+**Expected log output (in order):**
+
+```
+BacktestLoader: loaded bars { symbol: 'SPY', count: <N>, timeframe: '1Min' }
+BacktestLoader: loaded bars { symbol: 'QQQ', count: <N>, timeframe: '1Min' }
+```
+
+Expected bar counts: roughly 97,000–100,000 per symbol (252 trading days × ~390 1-min bars/day).
+
+After both symbols load, the engine will run through all bars and attempt to persist to Supabase:
+
+```
+runtime/backtest: completed { id: '...', totalReturn: '0.00%', ... }
+runtime/backtest: result persisted { id: '...' }
+```
+
+> `totalReturn` will be near 0% at this point because `_computeQty()` always returns 1 and
+> metrics are placeholders — that is expected and will be fixed in Tasks 2 and 3.
+
+**Confirm in Supabase** → Table Editor → `backtest_results` that a row exists with `status = 'completed'`.
+
+**Common errors:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Missing required environment variable: ALPACA_API_KEY` | `.env` not loaded or key missing | Re-check Part 1 Step 2 |
+| `403 Forbidden` from Alpaca | Wrong key type or key not activated | Use paper trading keys only |
+| `401 Unauthorized` | Typo in key or secret | Copy-paste directly from Alpaca dashboard |
+| `insertBacktestResult failed` | `backtest_results` table does not exist | Re-run Part 1 Step 4 SQL |
+
+---
+
+## Part 3 — Task 2: Fix `_computeQty()` in `pairsStrategy.ts`
+
+**File:** `backend/src/strategies/pairs/pairsStrategy.ts`
+
+### The problem
+
+`_computeQty()` at line 273 always returns `1`. It has no access to the current price because it is a parameterless method with no reference to `symbolState`. The fix requires two changes:
+
+### Step 1 — Add `latestLeg1Price` to `PairsInternalState`
+
+**File:** `backend/src/strategies/pairs/pairsTypes.ts`
+
+Add one field to `PairsInternalState`:
+
+```typescript
+/** Most recent leg1 price used for position sizing */
+latestLeg1Price: number | null;
+```
+
+### Step 2 — Cache the price during `evaluate()`
+
+In `pairsStrategy.ts`, the `evaluate()` method resolves `price1` at line 69 but does a null guard at line 76: `if (price1 === null || price2 === null) return null;`. The cache must go **after** that guard (line 78 onwards) — otherwise `price1` could still be null and the TypeScript type will complain.
+
+Add the cache line at line 78, after the null check:
+
+```typescript
+// Line 76: if (price1 === null || price2 === null) return null;  ← must be BEFORE this line
+// Line 77: (blank)
+// Line 78: add here ↓
+this.state.latestLeg1Price = price1;
+
+// Line 79: // Update hedge ratio if using rolling OLS ...
+const hedgeRatio = this._getHedgeRatio(price1, price2);
+```
+
+### Step 3 — Update `_initState()`
+
+Add the new field to the initial state object returned by `_initState()` at line 279:
+
+```typescript
+latestLeg1Price: null,
+```
+
+### Step 4 — Implement `_computeQty()`
+
+Replace the placeholder at line 273:
+
+```typescript
+private _computeQty(): number {
+  const price = this.state.latestLeg1Price;
+  if (!price || price <= 0) return 0;
+  return Math.floor(this.pairsConfig.tradeNotionalUsd / price);
+}
+```
+
+**Verify:** After this change, re-run `npm run dev:backtest`. Orders in the result stored in Supabase should now have `qty > 1` on most fills (SPY is ~$400–500, so `$5000 / $450 ≈ 11 shares`).
+
+---
+
+## Part 4 — Task 3: Implement Performance Metrics
+
+**File:** `backend/src/core/backtest/backtestEngine.ts`
+
+The `_computeMetrics()` method at line 145 has `winRate`, `totalTrades`, `avgWin`, and `avgLoss` hardcoded to `0`. The fills are already available — `orderState.getAllOrders().flatMap(o => o.fills)` is passed into the result at line 128.
+
+Update `_computeMetrics()` to accept the fills array and compute the real values.
+
+### Step 1 — Update the method signature
+
+Change the signature to accept fills:
+
+```typescript
+private _computeMetrics(
+  equityCurve: PortfolioSnapshot[],
+  fills: Fill[],
+  initialCapital: number,
+  periodStart: number,
+  periodEnd: number,
+)
+```
+
+Add the `Fill` import at the top of the file:
+
+```typescript
+import type { Fill } from "../../types/orders";
+```
+
+### Note on the early-return branch
+
+`_computeMetrics` has a second return path at line 151 for when `equityCurve.length === 0`. That path still returns zeros for all trade metrics — this is correct and does not need to change. No bars means no fills means no trades. TypeScript will not complain because the `fills` parameter is simply unused in that branch.
+
+### Step 2 — Compute trade-level metrics from fills
+
+Fills are individual executions. A completed round-trip trade is a `buy` fill followed by a `sell` fill (or vice versa for a short). The simplest approach: pair fills by order side within each strategy signal.
+
+Add this logic inside `_computeMetrics()`, replacing the hardcoded zeros:
+
+```typescript
+// Group fills into round-trip P&L values
+// Each paired buy+sell on the same symbol is one trade
+const pnlPerTrade: number[] = [];
+const buyMap = new Map<string, Fill[]>(); // symbol → open buy fills
+
+for (const fill of fills) {
+  if (fill.side === "buy") {
+    const existing = buyMap.get(fill.symbol) ?? [];
+    existing.push(fill);
+    buyMap.set(fill.symbol, existing);
+  } else {
+    const buys = buyMap.get(fill.symbol);
+    if (buys && buys.length > 0) {
+      const matchedBuy = buys.shift()!;
+      const pnl = (fill.price - matchedBuy.price) * fill.qty - fill.commission - matchedBuy.commission;
+      pnlPerTrade.push(pnl);
+    }
+  }
+}
+
+const totalTrades = pnlPerTrade.length;
+const wins = pnlPerTrade.filter((p) => p > 0);
+const losses = pnlPerTrade.filter((p) => p <= 0);
+const winRate = totalTrades > 0 ? wins.length / totalTrades : 0;
+const avgWin = wins.length > 0 ? wins.reduce((a, b) => a + b, 0) / wins.length : 0;
+const avgLoss = losses.length > 0 ? losses.reduce((a, b) => a + b, 0) / losses.length : 0;
+```
+
+### Step 3 — Pass fills from the `run()` call site
+
+In the `run()` method at line 125, update the `_computeMetrics()` call to pass fills.
+Since `result` is not yet built at that point, extract `fills` first:
+
+```typescript
+const fills = orderState.getAllOrders().flatMap((o) => o.fills);
+
+const result: BacktestResult = {
+  // ...
+  fills,
+  metrics: this._computeMetrics(equityCurve, fills, config.initialCapital, startedAt, completedAt),
+  // ...
+};
+```
+
+**Verify:** Re-run `npm run dev:backtest`. The logged `totalReturn` should now be non-zero, and the Supabase row's `metrics` column should contain real values for `winRate`, `totalTrades`, `avgWin`, and `avgLoss`.
+
+---
+
+## Part 5 — Task 4: Test the HTTP Endpoint
+
+The issue goal is `POST /api/backtests/run` working end-to-end, not just the CLI. After
+completing Tasks 2 and 3, verify the HTTP path as well.
+
+### Step 1 — Start the API server
+
+In a terminal:
+
+```bash
+npm run dev
+```
+
+You should see:
+
+```
+Backend API server started on port 3001
+```
+
+### Step 2 — Trigger a backtest via HTTP
+
+In a second terminal:
+
+```bash
+curl -X POST http://localhost:3001/api/backtests/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "SPY/QQQ HTTP test",
+    "strategyConfig": {
+      "type": "pairs_trading",
+      "symbols": ["SPY", "QQQ"]
+    },
+    "startDate": "2023-01-01T00:00:00Z",
+    "endDate": "2023-03-31T23:59:59Z"
+  }'
+```
+
+> Using a 3-month window here instead of the full year to keep the HTTP test fast (~25,000 bars vs 200,000).
+
+Expected immediate response (HTTP 202):
+
+```json
+{ "backtestId": "<uuid>", "message": "Backtest queued" }
+```
+
+The backtest runs in the background. Watch the server terminal for:
+
+```
+BacktestLoader: loaded bars { symbol: 'SPY', ... }
+BacktestLoader: loaded bars { symbol: 'QQQ', ... }
+BacktestEngine: completed { ... }
+Backtest completed and saved { id: '<uuid>' }
+```
+
+### Step 3 — Retrieve the result via HTTP
+
+```bash
+curl http://localhost:3001/api/backtests/<uuid>
+```
+
+Replace `<uuid>` with the `backtestId` from the 202 response. Expected: a full JSON
+`BacktestResult` with non-zero `metrics.totalTrades` and a non-empty `equityCurve` array.
+
+Also confirm `GET /api/backtests` lists the result:
+
+```bash
+curl http://localhost:3001/api/backtests
+```
+
+**Common errors:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| Server crashes immediately on `npm run dev` | Missing env vars | Re-check Part 1 Steps 2–3 |
+| 202 returned but no log output after | `setImmediate` callback failed silently | Check server terminal for error logs |
+| Result has `status: 'failed'` | Engine or Supabase error during async run | Check server terminal for `Backtest failed` log line |
+
+---
+
+## Part 6 — Final Verification
+
+Check all of the following before closing the issue:
+
+- [ ] Bar counts for both SPY and QQQ log above 90,000 (full-year CLI run)
+- [ ] No errors during bar loading or engine run
+- [ ] `totalReturn` in the log is non-zero
+- [ ] A row in Supabase `backtest_results` has `status = 'completed'`
+- [ ] The `metrics` column has non-zero values for `winRate` and `totalTrades`
+- [ ] The `fills` column has entries with `qty > 1`
+- [ ] The `equity_curve` column is a non-empty array
+- [ ] `POST /api/backtests/run` returns HTTP 202 and a `backtestId`
+- [ ] `GET /api/backtests/:id` returns the full result after the background run completes
+- [ ] `GET /api/backtests` lists the result

--- a/replay_setup.md
+++ b/replay_setup.md
@@ -1,0 +1,446 @@
+# Replay System — Build Guide
+
+The `ReplayEngine` (`backend/src/core/replay/replayEngine.ts`) is fully implemented.
+What remains is wiring it to the API, creating the Supabase table, and building the
+event recorder so there is data to replay.
+
+Complete the steps below in order.
+
+---
+
+## Part 1 — Prerequisites
+
+Replay shares the same backend environment as backtest. If you have already completed
+Part 1 of `backtest_setup.md` (npm install, `.env` file, Supabase keys), skip to Part 2.
+
+Otherwise complete those steps first — replay requires the same Alpaca and Supabase
+credentials.
+
+---
+
+## Part 2 — Create the Supabase `event_logs` Table
+
+Open the Supabase dashboard → SQL Editor → New query. Paste and run:
+
+```sql
+create table if not exists event_logs (
+  id           uuid         primary key,
+  name         text         not null,
+  description  text,
+  source       text         not null,   -- 'live', 'backtest', 'synthetic'
+  run_id       uuid,                    -- FK to strategy_runs if from a live session
+  event_count  integer      not null,
+  events       jsonb        not null,   -- TradingEvent[] array
+  start_date   timestamptz  not null,
+  end_date     timestamptz  not null,
+  created_at   timestamptz  not null default now()
+);
+```
+
+Verify the table appears under Table Editor before continuing.
+
+---
+
+## Part 3 — Add Repository Functions for `event_logs`
+
+**File:** `backend/src/adapters/supabase/repositories.ts`
+
+Add the following functions at the bottom of the file, following the same pattern as the existing backtest result functions:
+
+```typescript
+// ------------------------------------------------------------------
+// Event Logs (Replay)
+// ------------------------------------------------------------------
+
+export async function insertEventLog(log: EventLogRecord & { events: TradingEvent[] }): Promise<void> {
+  const supabase = getSupabaseClient();
+  const { error } = await supabase.from("event_logs").insert({
+    id: log.id,
+    name: log.name,
+    description: log.description,
+    source: log.source,
+    run_id: log.runId,
+    event_count: log.eventCount,
+    events: log.events,
+    start_date: log.startDate,
+    end_date: log.endDate,
+  });
+  if (error) logger.error("insertEventLog failed", { error: error.message });
+}
+
+export async function getAllEventLogs(): Promise<EventLogRecord[]> {
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase
+    .from("event_logs")
+    .select("id, name, description, source, run_id, event_count, start_date, end_date, created_at")
+    .order("created_at", { ascending: false });
+  if (error) {
+    logger.error("getAllEventLogs failed", { error: error.message });
+    return [];
+  }
+  return (data ?? []).map((row) => ({
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    source: row.source,
+    runId: row.run_id,
+    eventCount: row.event_count,
+    startDate: row.start_date,
+    endDate: row.end_date,
+    createdAt: new Date(row.created_at).getTime(),
+  })) as EventLogRecord[];
+}
+
+export async function getEventLogById(id: UUID): Promise<(EventLogRecord & { events: TradingEvent[] }) | null> {
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase
+    .from("event_logs")
+    .select("*")
+    .eq("id", id)
+    .single();
+  if (error) {
+    logger.error("getEventLogById failed", { error: error.message });
+    return null;
+  }
+  return {
+    id: data.id,
+    name: data.name,
+    description: data.description,
+    source: data.source,
+    runId: data.run_id,
+    eventCount: data.event_count,
+    events: data.events as TradingEvent[],
+    startDate: data.start_date,
+    endDate: data.end_date,
+    createdAt: new Date(data.created_at).getTime(),
+  };
+}
+```
+
+Add the required imports at the top of `repositories.ts`:
+
+```typescript
+import type { EventLogRecord } from "../../types/replay";
+import type { TradingEvent } from "../../types/events";
+```
+
+---
+
+## Part 4 — Inject `ReplayEngine` into the Express App
+
+The `ReplayEngine` instance is created in `runtime/replay.ts` but never passed to
+the controllers. The fix is to pass it through the Express app context.
+
+### Step 1 — Update `createApp()` to accept a `ReplayEngine`
+
+**File:** `backend/src/app/index.ts`
+
+Change the `createApp` signature to accept an optional `ReplayEngine`:
+
+```typescript
+import { ReplayEngine } from "../core/replay/replayEngine";
+
+export function createApp(replayEngine?: ReplayEngine): express.Application {
+  const app = express();
+
+  // Store on app.locals so controllers can access it
+  if (replayEngine) {
+    app.locals["replayEngine"] = replayEngine;
+  }
+
+  // ... rest of existing middleware setup unchanged ...
+}
+```
+
+### Step 2 — Pass the engine from `runtime/replay.ts`
+
+**File:** `backend/src/runtime/replay.ts`
+
+Update the `createApp()` call to pass the engine:
+
+```typescript
+const app = createApp(replayEngine);
+```
+
+### Step 3 — Update `runtime/live.ts` (no-op pass)
+
+**File:** `backend/src/runtime/live.ts`
+
+The live runtime calls `createApp()` with no arguments — this is fine as-is since
+`replayEngine` is optional. No change needed.
+
+---
+
+## Part 5 — Wire Up `replayController.ts`
+
+**File:** `backend/src/app/controllers/replayController.ts`
+
+Replace the entire file with the following implementation. Each function reads the
+`ReplayEngine` from `req.app.locals` and calls the appropriate method.
+
+```typescript
+import type { Request, Response } from "express";
+import { ReplayEngine } from "../../core/replay/replayEngine";
+import {
+  getAllEventLogs,
+  getEventLogById,
+} from "../../adapters/supabase/repositories";
+import { logger } from "../../utils/logger";
+import { newId } from "../../utils/ids";
+import { nowMs } from "../../utils/time";
+import type { ReplayCommand, ReplaySession } from "../../types/replay";
+
+function getEngine(req: Request): ReplayEngine | null {
+  return (req.app.locals["replayEngine"] as ReplayEngine) ?? null;
+}
+
+export async function listReplaySessions(req: Request, res: Response): Promise<void> {
+  try {
+    const logs = await getAllEventLogs();
+    res.json(logs);
+  } catch (err) {
+    logger.error("listReplaySessions error", { err });
+    res.status(500).json({ error: "Failed to fetch replay sessions" });
+  }
+}
+
+export async function loadReplaySession(req: Request, res: Response): Promise<void> {
+  const { sessionId } = req.body as { sessionId: string };
+  if (!sessionId) {
+    res.status(400).json({ error: "sessionId is required" });
+    return;
+  }
+
+  const engine = getEngine(req);
+  if (!engine) {
+    res.status(503).json({ error: "ReplayEngine not available in this runtime mode" });
+    return;
+  }
+
+  try {
+    const log = await getEventLogById(sessionId);
+    if (!log) {
+      res.status(404).json({ error: `Event log ${sessionId} not found` });
+      return;
+    }
+
+    const session: ReplaySession = {
+      id: newId(),
+      name: log.name,
+      sourceRunId: log.runId,
+      events: log.events,
+      totalEvents: log.events.length,
+      cursor: 0,
+      status: "paused",
+      speed: 1,
+      replayStrategies: false,
+      simulatedNow: log.events[0]?.ts ?? nowMs(),
+      createdAt: nowMs(),
+      description: log.description,
+    };
+
+    engine.load(session);
+    logger.info("loadReplaySession: session loaded", { sessionId, totalEvents: session.totalEvents });
+    res.json({ message: "Session loaded", session: engine.getSession() });
+  } catch (err) {
+    logger.error("loadReplaySession error", { sessionId, err });
+    res.status(500).json({ error: "Failed to load replay session" });
+  }
+}
+
+export async function controlReplay(req: Request, res: Response): Promise<void> {
+  const command = req.body as ReplayCommand;
+  if (!command?.action) {
+    res.status(400).json({ error: "command.action is required" });
+    return;
+  }
+
+  const engine = getEngine(req);
+  if (!engine) {
+    res.status(503).json({ error: "ReplayEngine not available in this runtime mode" });
+    return;
+  }
+
+  engine.control(command);
+  logger.info("controlReplay: command applied", { action: command.action });
+  res.json({ message: "Command applied", session: engine.getSession() });
+}
+
+export async function getReplayStatus(req: Request, res: Response): Promise<void> {
+  const engine = getEngine(req);
+  if (!engine) {
+    res.json(null);
+    return;
+  }
+  res.json(engine.getSession());
+}
+```
+
+---
+
+## Part 6 — Build the Event Recorder
+
+The replay engine plays back a `TradingEvent[]` stored in `event_logs`. Something must
+write those events during a live session. The `EventBus` already has an `onAll(handler)`
+method designed for exactly this purpose.
+
+Create a new file `backend/src/core/replay/eventRecorder.ts`:
+
+```typescript
+/**
+ * core/replay/eventRecorder.ts
+ *
+ * Records all TradingEvents published to an EventBus during a session.
+ * Call start() to begin recording and stop() to get the captured events.
+ * The captured log can then be persisted to the event_logs table for replay.
+ */
+
+import { EventBus } from "../engine/eventBus";
+import type { TradingEvent } from "../../types/events";
+
+export class EventRecorder {
+  private events: TradingEvent[] = [];
+  private recording = false;
+  private readonly handler = (event: TradingEvent): void => {
+    this.events.push(event);
+  };
+
+  constructor(private readonly eventBus: EventBus) {}
+
+  start(): void {
+    if (this.recording) return;
+    this.events = [];
+    this.recording = true;
+    this.eventBus.onAll(this.handler);
+  }
+
+  stop(): TradingEvent[] {
+    if (!this.recording) return this.events;
+    this.recording = false;
+    this.eventBus.offAll(this.handler);
+    return this.events;
+  }
+
+  get isRecording(): boolean {
+    return this.recording;
+  }
+}
+```
+
+### Wire the recorder into `runtime/live.ts`
+
+**File:** `backend/src/runtime/live.ts`
+
+Import and start the recorder, then persist the log on shutdown:
+
+```typescript
+import { EventRecorder } from "../core/replay/eventRecorder";
+import { insertEventLog } from "../adapters/supabase/repositories";
+import { newId } from "../utils/ids";
+import { nowIso } from "../utils/time";
+
+// After eventBus is created:
+const recorder = new EventRecorder(eventBus);
+recorder.start();
+
+// In the shutdown function, before process.exit(0):
+const events = recorder.stop();
+if (events.length > 0) {
+  await insertEventLog({
+    id: newId(),
+    name: `Live session ${new Date().toISOString()}`,
+    source: "live",
+    eventCount: events.length,
+    events,
+    startDate: nowIso(),
+    endDate: nowIso(),
+    createdAt: Date.now(),
+  });
+  logger.info("runtime/live: event log persisted", { eventCount: events.length });
+}
+```
+
+---
+
+## Part 7 — Smoke Test End-to-End
+
+### 7a. Generate a replay session
+
+Start the live paper trading runtime and let it run for at least a few minutes so
+market data events are recorded:
+
+```bash
+npm run dev:live
+```
+
+Stop it with `Ctrl+C`. You should see:
+
+```
+runtime/live: event log persisted { eventCount: <N> }
+```
+
+Confirm in Supabase → Table Editor → `event_logs` that a row was inserted.
+
+### 7b. Start the replay runtime
+
+```bash
+npm run dev:replay
+```
+
+You should see:
+
+```
+Replay API server listening on port 3001
+```
+
+### 7c. Test the API endpoints
+
+List available sessions:
+
+```bash
+curl http://localhost:3001/api/replay/sessions
+```
+
+Expected: a JSON array containing the session recorded in step 7a.
+
+Load a session (replace `<id>` with the `id` from the list):
+
+```bash
+curl -X POST http://localhost:3001/api/replay/load \
+  -H "Content-Type: application/json" \
+  -d '{"sessionId": "<id>"}'
+```
+
+Expected: `{ "message": "Session loaded", "session": { "status": "paused", ... } }`
+
+Start playback:
+
+```bash
+curl -X POST http://localhost:3001/api/replay/control \
+  -H "Content-Type: application/json" \
+  -d '{"action": "play"}'
+```
+
+Check status while playing:
+
+```bash
+curl http://localhost:3001/api/replay/status
+```
+
+Expected: `cursor` should be advancing; `status` should be `"playing"` and eventually `"completed"`.
+
+---
+
+## Checklist
+
+- [ ] `event_logs` table created in Supabase
+- [ ] Repository functions (`insertEventLog`, `getAllEventLogs`, `getEventLogById`) added
+- [ ] `createApp()` accepts and stores `ReplayEngine` on `app.locals`
+- [ ] `runtime/replay.ts` passes `replayEngine` to `createApp()`
+- [ ] `replayController.ts` fully implemented (no 501s)
+- [ ] `EventRecorder` class created
+- [ ] `runtime/live.ts` starts recorder on boot and persists log on shutdown
+- [ ] `GET /api/replay/sessions` returns a non-empty array after a live session
+- [ ] `POST /api/replay/load` loads a session without error
+- [ ] `POST /api/replay/control` with `{"action": "play"}` starts playback
+- [ ] `GET /api/replay/status` shows `cursor` advancing during playback


### PR DESCRIPTION
# Pull Request — Changes Summary

## Overview

This PR covers bug fixes, a security patch, a server port migration, and a new live system health feature wired end-to-end from the backend to the dashboard.

---

## 1. Security — Removed Vulnerable Alpaca Package (`782c628`)

**Files:** `backend/package.json`, `backend/package-lock.json`, `frontend/package-lock.json`

Removed an unused Alpaca SDK package that pulled in an `axios` version with a known vulnerability. The backend already used native `fetch` for all Alpaca calls — the package had no active usage. Lock files were regenerated to resolve the dependency tree.

---

## 2. Bug Fixes — Frontend Routes & Backtest Type Mismatch (`813abb2`)

### Frontend import path errors
All four page components were importing feature components from the wrong path (missing subdirectory):

| Page | Was | Now |
|---|---|---|
| `app/backtest/page.tsx` | `features/BacktestForm` | `features/backtest/BacktestForm` |
| `app/backtest/page.tsx` | `features/BacktestResults` | `features/backtest/BacktestResults` |
| `app/portfolio/page.tsx` | `features/PortfolioMetrics` | `features/portfolio/PortfolioMetrics` |
| `app/replay/page.tsx` | `features/ReplayPlayer` | `features/replay/ReplayPlayer` |
| `app/strategies/page.tsx` | `features/StrategyForm` | `features/strategy/StrategyForm` |
| `app/strategies/page.tsx` | `features/StrategyList` | `features/strategy/StrategyList` |

### `BacktestResult` type shape mismatch (TS2352)
The `BacktestResult` interface used camelCase field names (`startedAt`, `finalPortfolio`, `equityCurve`, `eventCount`) while the Supabase schema returns snake_case (`started_at`, `final_portfolio`, `equity_curve`, `event_count`). TypeScript caught this as an invalid cast.

**Fix:** Renamed the affected fields in `BacktestResult` to snake_case to match the DB schema, and updated all construction sites in `backtestEngine.ts` and `runtime/backtest.ts`.

### Additional TypeScript fixes
- **`env.ts`:** Renamed local helper `require()` → `requireEnv()` — `require` is a reserved identifier in TypeScript module scope (TS2441)
- **`backtestController.ts`:** Fixed Express route param type — `req.params.id` is typed `string | string[]`; asserted to `string` since route params are always scalar (TS2345)

---

## 3. Backend Port Migration & Connection Fix (`47a5f61`)

**Files:** `backend/src/config/env.ts`, `backend/.env.example`, `frontend/config/index.ts`, `backend/src/index.ts`, `README.md`, `backtest_setup.md`, `replay_setup.md`

### Port changed from 3001 → 8080
8080 is the standard alternative HTTP port used across Docker, cloud platforms, and most backend frameworks.

All references updated across source files, config defaults, and documentation.

### Express listen error handling
Diagnosed a silent failure mode in Express 5: when `app.listen()` fails (e.g. `EADDRINUSE` — port already in use), Express 5 calls the startup callback with the error rather than emitting it. Since the callback didn't check for errors, the server logged a false "started" message and then exited cleanly with no visible failure.

**Fix:** Captured the server reference and added an explicit `error` event handler that logs the specific reason and exits with code 1.

```
Port 8080 is already in use. Is another server instance running?
```

---

## 4. System Health Card — Live Dashboard Integration (`833cb41`)

**Files:** `backend/src/app/controllers/systemController.ts`, `frontend/types/api.ts`, `frontend/services/systemService.ts` *(new)*, `frontend/hooks/useSystemHealth.ts` *(new)*, `frontend/components/cards/SystemHealthCard.tsx`, `frontend/app/dashboard/page.tsx`, `frontend/app/layout.tsx`

### Backend — Real connectivity checks (`GET /api/system/status`)
Replaced the hardcoded placeholder response with actual async checks:

- **Supabase:** Lightweight read query against `backtest_results`. Maps error codes to readable messages.
- **Alpaca:** `GET /v2/account` against the configured paper or live base URL. Returns account status on success.
- **Overall status:** `healthy` (both OK) / `degraded` (one OK) / `unhealthy` (both failing)

### New frontend types
Added to `frontend/types/api.ts`:
- `SystemHealthStatus = "healthy" | "degraded" | "unhealthy"`
- `ExecutionMode = "paper" | "live" | "backtest" | "replay" | "unknown"`
- `ServiceHealth { health: boolean; error?: string; accountStatus?: string }`
- `SystemStatus` updated with `services: { backend, supabase, alpaca }` and typed `mode`

### New service and hook
- `services/systemService.ts` — `fetchSystemStatus()` using the shared `apiGet` client
- `hooks/useSystemHealth.ts` — polls `GET /api/system/status` every 30 seconds; synthesizes a full failed status (including backend unreachable) if the fetch throws, so the card always renders something meaningful

### Backend as a third service check
The backend server's reachability is implicitly validated by whether the status fetch succeeds. On failure, the hook synthesizes:
```
backend:  { health: false, error: "<network error message>" }
supabase: { health: false, error: "Unknown (backend unreachable)" }
alpaca:   { health: false, error: "Unknown (backend unreachable)" }
```

### Updated `SystemHealthCard`
- Overall status banner: green / yellow / red with label
- Per-service rows with green or red dot
- Error message displayed inline below each failing service
- Mode and last-updated timestamp in footer

### Hydration warning fix (`frontend/app/layout.tsx`)
Added `suppressHydrationWarning` to `<body>` to suppress React hydration mismatches caused by the Grammarly browser extension injecting attributes (`data-gr-ext-installed`, `data-new-gr-c-s-check-loaded`) into the DOM after SSR.

---

## 5. Error Codes in Health Card (`6cba1a8`)

**Files:** `backend/src/app/controllers/systemController.ts`

HTTP status codes and Supabase error codes are now included in error message strings so they appear in the dashboard:

| Scenario | Error displayed |
|---|---|
| Bad Alpaca key | `[401] Invalid Alpaca API key or secret` |
| Alpaca forbidden | `[403] Account forbidden or not authorized` |
| Alpaca not found | `[404] Account not found` |
| Alpaca server error | `[500] Alpaca internal server error` |
| Unknown HTTP error | `[<status>] Alpaca API error` |
| Supabase auth error | `[<code>] Invalid Supabase credentials` |
| Other Supabase error | `[<code>] <message>` |
| Network unreachable | `Cannot reach <service> (network error)` |
