### PR TITLE
DI wiring for parallel instance graphs per system (Backtest, replay, Live), OLS Rolling Hedge Ratio for Pairs Trading Strategy

### DIFF
--- a/backend/src/app/context.ts
+++ b/backend/src/app/context.ts
@@ -1,0 +1,9 @@
+import type { Orchestrator } from "../core/engine/orchestrator";
+import type { SymbolStateManager } from "../core/state/symbolState";
+import type { ReplayEngine } from "../core/replay/replayEngine";
+
+export interface AppContext {
+  orchestrator?: Orchestrator;
+  symbolState?: SymbolStateManager;
+  replayEngine?: ReplayEngine;
+}

--- a/backend/src/app/controllers/marketDataController.ts
+++ b/backend/src/app/controllers/marketDataController.ts
@@ -1,37 +1,34 @@
-/**
- * app/controllers/marketDataController.ts
- *
- * Controller for market data endpoints.
- * Returns current symbol state snapshots and recent quote/trade history
- * from the in-memory SymbolStateManager for frontend display.
- *
- * Inputs:  HTTP requests from the frontend dashboard.
- * Outputs: JSON symbol state and market data snapshots.
- */
-
 import type { Request, Response } from "express";
 import { logger } from "../../utils/logger";
+import type { AppContext } from "../context";
 
 /**
  * GET /api/market-data/symbols
- * Returns the list of symbols currently tracked in the engine's symbol state.
- * @param req - Express Request
- * @param res - Express Response: string[] symbol list
  */
 export async function getTrackedSymbols(req: Request, res: Response): Promise<void> {
-  // TODO: Return symbols from the live SymbolStateManager
-  res.json([]);
+  const { symbolState } = req.app.locals.ctx as AppContext;
+  if (!symbolState) {
+    res.json([]);
+    return;
+  }
+  res.json(symbolState.getSymbols());
 }
 
 /**
  * GET /api/market-data/snapshot/:symbol
- * Returns the latest quote snapshot for a specific symbol.
- * @param req - Express Request with params.symbol
- * @param res - Express Response: Quote JSON or 404
  */
 export async function getSymbolSnapshot(req: Request, res: Response): Promise<void> {
   const { symbol } = req.params;
-  // TODO: Query live SymbolStateManager for symbol state
-  logger.debug("getSymbolSnapshot", { symbol });
-  res.status(404).json({ error: `No live data for ${symbol}` });
+  const { symbolState } = req.app.locals.ctx as AppContext;
+  if (!symbolState) {
+    res.status(404).json({ error: `No live data for ${symbol}` });
+    return;
+  }
+  const state = symbolState.get(String(symbol));
+  if (!state) {
+    logger.debug("getSymbolSnapshot: symbol not tracked", { symbol });
+    res.status(404).json({ error: `No live data for ${symbol}` });
+    return;
+  }
+  res.json(state);
 }

--- a/backend/src/app/controllers/replayController.ts
+++ b/backend/src/app/controllers/replayController.ts
@@ -1,35 +1,20 @@
-/**
- * app/controllers/replayController.ts
- *
- * Controller for replay session endpoints.
- * Handles listing available event logs, loading sessions, and
- * sending playback control commands (play, pause, step, seek, speed).
- *
- * Inputs:  HTTP requests from the frontend replay view.
- * Outputs: JSON session state; forwards commands to the ReplayEngine.
- */
-
 import type { Request, Response } from "express";
 import { logger } from "../../utils/logger";
 import type { ReplayCommand } from "../../types/replay";
+import type { AppContext } from "../context";
 
 /**
  * GET /api/replay/sessions
- * Lists available recorded event log sessions that can be replayed.
- * @param req - Express Request
- * @param res - Express Response: EventLogRecord[] JSON array
+ * TODO: Query event_logs table via Supabase repository once that repo function exists.
  */
-export async function listReplaySessions(req: Request, res: Response): Promise<void> {
-  // TODO: Query event_logs table via Supabase repository
+export async function listReplaySessions(_req: Request, res: Response): Promise<void> {
   res.json([]);
 }
 
 /**
  * POST /api/replay/load
- * Loads a specific event log session into the ReplayEngine.
  * Body: { sessionId: string }
- * @param req - Express Request with sessionId in body
- * @param res - Express Response: { message: string, session: ReplaySession }
+ * TODO: Load event log from DB and construct a ReplaySession once the repository function exists.
  */
 export async function loadReplaySession(req: Request, res: Response): Promise<void> {
   const { sessionId } = req.body as { sessionId: string };
@@ -37,17 +22,18 @@ export async function loadReplaySession(req: Request, res: Response): Promise<vo
     res.status(400).json({ error: "sessionId is required" });
     return;
   }
-  // TODO: Load event log from DB, instantiate ReplayEngine, load session
+  const { replayEngine } = req.app.locals.ctx as AppContext;
+  if (!replayEngine) {
+    res.status(503).json({ error: "Replay engine not available in this runtime mode" });
+    return;
+  }
   logger.info("loadReplaySession: received request", { sessionId });
-  res.status(501).json({ error: "Not yet implemented" });
+  res.status(501).json({ error: "event_logs repository not yet implemented" });
 }
 
 /**
  * POST /api/replay/control
- * Sends a playback control command to the active ReplayEngine.
  * Body: ReplayCommand
- * @param req - Express Request with ReplayCommand in body
- * @param res - Express Response: { message: string }
  */
 export async function controlReplay(req: Request, res: Response): Promise<void> {
   const command = req.body as ReplayCommand;
@@ -55,18 +41,24 @@ export async function controlReplay(req: Request, res: Response): Promise<void> 
     res.status(400).json({ error: "command.action is required" });
     return;
   }
-  // TODO: Forward command to the active ReplayEngine instance
-  logger.info("controlReplay: received command", { action: command.action });
-  res.status(501).json({ error: "Not yet implemented" });
+  const { replayEngine } = req.app.locals.ctx as AppContext;
+  if (!replayEngine) {
+    res.status(503).json({ error: "Replay engine not available in this runtime mode" });
+    return;
+  }
+  replayEngine.control(command);
+  logger.info("controlReplay: command applied", { action: command.action });
+  res.json({ message: `Command '${command.action}' applied` });
 }
 
 /**
  * GET /api/replay/status
- * Returns the current status of the active replay session.
- * @param req - Express Request
- * @param res - Express Response: ReplaySession JSON or null
  */
 export async function getReplayStatus(req: Request, res: Response): Promise<void> {
-  // TODO: Return current ReplayEngine session state
-  res.json(null);
+  const { replayEngine } = req.app.locals.ctx as AppContext;
+  if (!replayEngine) {
+    res.json(null);
+    return;
+  }
+  res.json(replayEngine.getSession());
 }

--- a/backend/src/app/controllers/strategiesController.ts
+++ b/backend/src/app/controllers/strategiesController.ts
@@ -1,25 +1,12 @@
-/**
- * app/controllers/strategiesController.ts
- *
- * Controller for strategy management endpoints.
- * Handles creating, starting, stopping, and listing strategy runs.
- * Delegates to the core Orchestrator for lifecycle management.
- *
- * Inputs:  HTTP requests from the frontend strategy management UI.
- * Outputs: JSON responses with strategy run state and metadata.
- */
-
 import type { Request, Response } from "express";
 import { getAllStrategyRuns } from "../../adapters/supabase/repositories";
 import { logger } from "../../utils/logger";
+import type { AppContext } from "../context";
 
 /**
  * GET /api/strategies
- * Returns all strategy run records from the database.
- * @param req - Express Request
- * @param res - Express Response: StrategyRun[] JSON array
  */
-export async function listStrategyRuns(req: Request, res: Response): Promise<void> {
+export async function listStrategyRuns(_req: Request, res: Response): Promise<void> {
   try {
     const runs = await getAllStrategyRuns();
     res.json(runs);
@@ -31,9 +18,6 @@ export async function listStrategyRuns(req: Request, res: Response): Promise<voi
 
 /**
  * GET /api/strategies/:id
- * Returns a single strategy run by ID.
- * @param req - Express Request with params.id
- * @param res - Express Response: StrategyRun JSON or 404
  */
 export async function getStrategyRun(req: Request, res: Response): Promise<void> {
   const { id } = req.params;
@@ -53,33 +37,35 @@ export async function getStrategyRun(req: Request, res: Response): Promise<void>
 
 /**
  * POST /api/strategies/start
- * Creates and starts a new strategy run.
  * Body: { strategyType: string, config: BaseStrategyConfig }
- * @param req - Express Request with strategy config in body
- * @param res - Express Response: { message: string, strategyId: string }
+ * TODO: Add a strategy factory/registry so strategies can be instantiated from JSON config.
  */
 export async function startStrategyRun(req: Request, res: Response): Promise<void> {
   const { strategyType, config } = req.body as { strategyType: string; config: unknown };
-
   if (!strategyType || !config) {
     res.status(400).json({ error: "strategyType and config are required" });
     return;
   }
-
-  // TODO: Instantiate strategy from config and register with the live Orchestrator
+  const { orchestrator } = req.app.locals.ctx as AppContext;
+  if (!orchestrator) {
+    res.status(503).json({ error: "Orchestrator not available in this runtime mode" });
+    return;
+  }
   logger.info("startStrategyRun: received request", { strategyType });
-  res.status(501).json({ error: "Not yet implemented — connect to Orchestrator instance" });
+  res.status(501).json({ error: "Strategy factory not yet implemented" });
 }
 
 /**
  * POST /api/strategies/:id/stop
- * Stops a running strategy run.
- * @param req - Express Request with params.id
- * @param res - Express Response: { message: string }
  */
 export async function stopStrategyRun(req: Request, res: Response): Promise<void> {
   const { id } = req.params;
-  // TODO: Deregister strategy from the live Orchestrator
-  logger.info("stopStrategyRun: received request", { id });
-  res.status(501).json({ error: "Not yet implemented — connect to Orchestrator instance" });
+  const { orchestrator } = req.app.locals.ctx as AppContext;
+  if (!orchestrator) {
+    res.status(503).json({ error: "Orchestrator not available in this runtime mode" });
+    return;
+  }
+  orchestrator.deregisterStrategy(String(id));
+  logger.info("stopStrategyRun: strategy deregistered", { id });
+  res.json({ message: `Strategy ${id} stopped` });
 }

--- a/backend/src/app/index.ts
+++ b/backend/src/app/index.ts
@@ -15,13 +15,11 @@ import { env } from "../config/env";
 import { requestLogger } from "./middleware/requestLogger";
 import { errorHandler } from "./middleware/errorHandler";
 import apiRoutes from "./routes/index";
+import type { AppContext } from "./context";
 
-/**
- * Creates and returns a configured Express application.
- * @returns Express Application
- */
-export function createApp(): express.Application {
+export function createApp(ctx: AppContext = {}): express.Application {
   const app = express();
+  app.locals.ctx = ctx;
 
   // ------ Core middleware ------
   app.use(cors({ origin: env.corsOrigin }));

--- a/backend/src/runtime/live.ts
+++ b/backend/src/runtime/live.ts
@@ -81,7 +81,7 @@ async function main(): Promise<void> {
   marketDataAdapter.subscribe(pairsConfig.symbols);
 
   // ---- Start API server ----
-  const app = createApp();
+  const app = createApp({ orchestrator, symbolState });
   app.listen(env.port, () => {
     logger.info(`API server listening on port ${env.port}`);
   });

--- a/backend/src/runtime/replay.ts
+++ b/backend/src/runtime/replay.ts
@@ -21,9 +21,7 @@ async function main(): Promise<void> {
   const eventBus = new EventBus();
   const replayEngine = new ReplayEngine(eventBus);
 
-  // TODO: Inject replayEngine into the Express app context so controllers can use it
-  // For now, start the API server — replay sessions are loaded via /api/replay/load
-  const app = createApp();
+  const app = createApp({ replayEngine });
   app.listen(env.port, () => {
     logger.info(`Replay API server listening on port ${env.port}`);
   });

--- a/backend/src/services/indicators/index.ts
+++ b/backend/src/services/indicators/index.ts
@@ -10,3 +10,4 @@ export * from "./ema";
 export * from "./sma";
 export * from "./volatility";
 export * from "./rsi";
+export * from "./ols";

--- a/backend/src/services/indicators/ols.ts
+++ b/backend/src/services/indicators/ols.ts
@@ -1,0 +1,71 @@
+/**
+ * services/indicators/ols.ts
+ *
+ * Ordinary Least Squares (OLS) regression for hedge ratio estimation.
+ * Regresses price1 on price2 to find the beta (slope) that minimizes
+ * the variance of the spread, producing the most stationary residuals.
+ *
+ * Used by the pairs trading strategy to compute a data-driven hedge ratio
+ * rather than relying on a fixed user-supplied value.
+ *
+ * Inputs:  Two equal-length price arrays (oldest first).
+ * Outputs: { beta, alpha } where beta is the hedge ratio, or null if
+ *          insufficient data.
+ */
+
+export interface OLSResult {
+  /** Slope coefficient — use this as the hedge ratio */
+  beta: number;
+  /** Intercept — the baseline spread level when price2 = 0 */
+  alpha: number;
+  /** R-squared — how well price2 explains price1 (0–1) */
+  rSquared: number;
+}
+
+/**
+ * Computes OLS regression of price1 on price2.
+ * Finds beta and alpha such that price1 ≈ alpha + beta * price2.
+ * Beta minimizes Var(price1 - beta * price2), giving the most stationary spread.
+ *
+ * Returns null if fewer than 2 observations are provided or if price2 has
+ * zero variance (constant series — hedge ratio undefined).
+ *
+ * @param price1s - Dependent variable (leg1 prices), oldest first
+ * @param price2s - Independent variable (leg2 prices), oldest first
+ * @returns OLSResult or null
+ */
+export function computeOLSHedgeRatio(
+  price1s: number[],
+  price2s: number[],
+): OLSResult | null {
+  const n = price1s.length;
+  if (n < 2 || n !== price2s.length) return null;
+
+  let sum1 = 0;
+  let sum2 = 0;
+  for (let i = 0; i < n; i++) {
+    sum1 += price1s[i];
+    sum2 += price2s[i];
+  }
+  const mean1 = sum1 / n;
+  const mean2 = sum2 / n;
+
+  let cov = 0;
+  let varX = 0;
+  let varY = 0;
+  for (let i = 0; i < n; i++) {
+    const d1 = price1s[i] - mean1;
+    const d2 = price2s[i] - mean2;
+    cov  += d2 * d1;
+    varX += d2 * d2;
+    varY += d1 * d1;
+  }
+
+  if (varX === 0) return null;
+
+  const beta  = cov / varX;
+  const alpha = mean1 - beta * mean2;
+  const rSquared = varY === 0 ? 1 : (cov * cov) / (varX * varY);
+
+  return { beta, alpha, rSquared };
+}

--- a/backend/src/strategies/pairs/pairsConfig.ts
+++ b/backend/src/strategies/pairs/pairsConfig.ts
@@ -29,16 +29,19 @@ export const DEFAULT_PAIRS_CONFIG: Omit<
   enabled: true,
 
   hedgeRatioMethod: "fixed",
-  fixedHedgeRatio: 1.0,
+  fixedHedgeRatio: 1,
 
-  entryZScore: 2.0,             // Enter when |z-score| > 2.0
+  entryZScore: 2,               // Enter when |z-score| > 2
   exitZScore: 0.5,              // Exit when |z-score| < 0.5
-  stopLossZScore: 4.0,          // Emergency stop at |z-score| = 4.0
+  stopLossZScore: 4,            // Emergency stop at |z-score| = 4
   maxHoldingTimeMs: 86_400_000, // Force-exit after 24 hours
   minObservations: 30,          // Need 30 data points for reliable stats
 
   tradeNotionalUsd: 5_000,      // $5,000 per leg
   priceSource: "mid",
+
+  olsWindowMs: 14_400_000,     // 4-hour OLS window (2× the spread window)
+  olsRecalcIntervalBars: 5,    // Recompute hedge ratio every 5 bars
 };
 
 /**

--- a/backend/src/strategies/pairs/pairsStrategy.ts
+++ b/backend/src/strategies/pairs/pairsStrategy.ts
@@ -25,6 +25,7 @@
 import { BaseStrategy } from "../base/strategy";
 import { RollingTimeWindow } from "../../core/state/rollingWindow";
 import { computeZScore } from "../../services/indicators/zscore";
+import { computeOLSHedgeRatio } from "../../services/indicators/ols";
 import { logger } from "../../utils/logger";
 import { nowMs } from "../../utils/time";
 import type { EvaluationContext } from "../base/strategy";
@@ -38,7 +39,7 @@ import type {
 export class PairsStrategy extends BaseStrategy {
   readonly type: StrategyType = "pairs_trading";
 
-  private state: PairsInternalState;
+  private readonly state: PairsInternalState;
 
   /**
    * @param config - Full PairsStrategyConfig (use createPairsConfig() helper)
@@ -76,12 +77,16 @@ export class PairsStrategy extends BaseStrategy {
     if (price1 === null || price2 === null) return null;
     this.state.latestLeg1Price = price1;
 
-    // Update hedge ratio if using rolling OLS (placeholder — uses fixed for now)
-    const hedgeRatio = this._getHedgeRatio(price1, price2);
+    // Feed price history windows for OLS hedge ratio estimation
+    const ts = nowMs();
+    this.state.olsLeg1Window.push({ ts, value: price1 });
+    this.state.olsLeg2Window.push({ ts, value: price2 });
+    this.state.barsSinceOlsRecalc++;
+
+    const hedgeRatio = this._getHedgeRatio();
 
     // Compute spread and update window
     const spread = price1 - hedgeRatio * price2;
-    const ts = nowMs();
     this.state.spreadWindow.push({ ts, value: spread });
     this.state.lastSpread = spread;
 
@@ -114,12 +119,34 @@ export class PairsStrategy extends BaseStrategy {
   // Private helpers
   // ------------------------------------------------------------------
 
-  private _getHedgeRatio(_price1: number, _price2: number): number {
+  private _getHedgeRatio(): number {
     if (this.pairsConfig.hedgeRatioMethod === "fixed") {
       return this.pairsConfig.fixedHedgeRatio;
     }
-    // rolling_ols: placeholder — will be implemented in services/indicators
-    return this.pairsConfig.fixedHedgeRatio;
+
+    // Only recompute every olsRecalcIntervalBars to avoid unnecessary work
+    if (this.state.barsSinceOlsRecalc < this.pairsConfig.olsRecalcIntervalBars) {
+      return this.state.currentHedgeRatio;
+    }
+    this.state.barsSinceOlsRecalc = 0;
+
+    const leg1Prices = this.state.olsLeg1Window.getValues();
+    const leg2Prices = this.state.olsLeg2Window.getValues();
+    const result = computeOLSHedgeRatio(leg1Prices, leg2Prices);
+
+    if (result === null) {
+      return this.state.currentHedgeRatio;
+    }
+
+    if (result.rSquared < 0.5) {
+      logger.warn("PairsStrategy: low OLS R² — pair may not be cointegrated", {
+        id: this.id,
+        rSquared: result.rSquared.toFixed(3),
+      });
+    }
+
+    this.state.currentHedgeRatio = result.beta;
+    return result.beta;
   }
 
   private _checkExitSignals(
@@ -289,6 +316,9 @@ export class PairsStrategy extends BaseStrategy {
       cooldownActive: false,
       cooldownExpiresAt: null,
       latestLeg1Price: null,
+      olsLeg1Window: new RollingTimeWindow(this.pairsConfig.olsWindowMs),
+      olsLeg2Window: new RollingTimeWindow(this.pairsConfig.olsWindowMs),
+      barsSinceOlsRecalc: 0,
     };
   }
 }

--- a/backend/src/strategies/pairs/pairsTypes.ts
+++ b/backend/src/strategies/pairs/pairsTypes.ts
@@ -93,6 +93,20 @@ export interface PairsStrategyConfig {
   maxHoldingTimeMs: number;
 
   /**
+   * Duration of the rolling window used for OLS hedge ratio estimation (ms).
+   * Should be longer than rollingWindowMs so the ratio is stable across
+   * multiple spread cycles. Ignored when hedgeRatioMethod = "fixed".
+   */
+  olsWindowMs: number;
+
+  /**
+   * How often to recompute the OLS hedge ratio, in number of bars received.
+   * Recomputing every bar is unnecessary and expensive; every 5–10 bars is typical.
+   * Ignored when hedgeRatioMethod = "fixed".
+   */
+  olsRecalcIntervalBars: number;
+
+  /**
    * Minimum number of spread observations required before trading.
    * Ensures the rolling statistics are meaningful.
    */
@@ -134,6 +148,12 @@ export interface PairsInternalState {
   cooldownExpiresAt: EpochMs | null;
   /** Most recent leg1 price used for position sizing */
   latestLeg1Price: number | null;
+  /** Price history window for leg1 used by rolling OLS */
+  olsLeg1Window: RollingTimeWindow<number>;
+  /** Price history window for leg2 used by rolling OLS */
+  olsLeg2Window: RollingTimeWindow<number>;
+  /** Bar count since last OLS recomputation */
+  barsSinceOlsRecalc: number;
 }
 
 // ------------------------------------------------------------------

--- a/frontend/features/strategy/StrategyForm.tsx
+++ b/frontend/features/strategy/StrategyForm.tsx
@@ -22,10 +22,13 @@ interface Props {
 export default function StrategyForm({ onSubmit, isLoading }: Props) {
   const [leg1, setLeg1] = useState("SPY");
   const [leg2, setLeg2] = useState("QQQ");
-  const [entryZScore, setEntryZScore] = useState(2.0);
+  const [entryZScore, setEntryZScore] = useState(2);
   const [exitZScore, setExitZScore] = useState(0.5);
-  const [rollingWindowMs, setRollingWindowMs] = useState(3_600_000);
+  const [rollingWindowMins, setRollingWindowMins] = useState(60);
   const [tradeNotionalUsd, setTradeNotionalUsd] = useState(5_000);
+  const [hedgeRatioMethod, setHedgeRatioMethod] = useState<"fixed" | "rolling_ols">("fixed");
+  const [olsWindowMins, setOlsWindowMins] = useState(240);
+  const [olsRecalcIntervalBars, setOlsRecalcIntervalBars] = useState(5);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -35,19 +38,21 @@ export default function StrategyForm({ onSubmit, isLoading }: Props) {
       leg1Symbol: leg1,
       leg2Symbol: leg2,
       symbols: [leg1, leg2],
-      rollingWindowMs,
+      rollingWindowMs: rollingWindowMins * 60_000,
       maxPositionSizeUsd: 10_000,
       cooldownMs: 60_000,
       enabled: true,
-      hedgeRatioMethod: "fixed",
-      fixedHedgeRatio: 1.0,
+      hedgeRatioMethod,
+      fixedHedgeRatio: 1,
       entryZScore,
       exitZScore,
-      stopLossZScore: 4.0,
+      stopLossZScore: 4,
       maxHoldingTimeMs: 86_400_000,
       minObservations: 30,
       tradeNotionalUsd,
       priceSource: "mid",
+      olsWindowMs: olsWindowMins * 60_000,
+      olsRecalcIntervalBars,
     });
   };
 
@@ -96,13 +101,13 @@ export default function StrategyForm({ onSubmit, isLoading }: Props) {
             className={inputClass}
           />
         </Field>
-        <Field label="Rolling Window (ms)">
+        <Field label="Spread Window (minutes)">
           <input
             type="number"
-            step="60000"
-            min="60000"
-            value={rollingWindowMs}
-            onChange={(e) => setRollingWindowMs(Number(e.target.value))}
+            step="5"
+            min="5"
+            value={rollingWindowMins}
+            onChange={(e) => setRollingWindowMins(Number(e.target.value))}
             className={inputClass}
           />
         </Field>
@@ -116,7 +121,47 @@ export default function StrategyForm({ onSubmit, isLoading }: Props) {
             className={inputClass}
           />
         </Field>
+        <Field label="Hedge Ratio Method">
+          <select
+            value={hedgeRatioMethod}
+            onChange={(e) => setHedgeRatioMethod(e.target.value as "fixed" | "rolling_ols")}
+            className={inputClass}
+          >
+            <option value="fixed">Fixed (1:1)</option>
+            <option value="rolling_ols">Rolling OLS</option>
+          </select>
+        </Field>
       </div>
+
+      {hedgeRatioMethod === "rolling_ols" && (
+        <div className="grid grid-cols-2 gap-3 rounded-md border border-zinc-200 p-3 dark:border-zinc-700">
+          <p className="col-span-2 text-xs text-zinc-500">
+            OLS estimates the hedge ratio by regressing leg 1 on leg 2 over the window below.
+            Use a window 2–4× longer than the spread window for a stable ratio.
+          </p>
+          <Field label="OLS Window (minutes)">
+            <input
+              type="number"
+              step="30"
+              min="30"
+              value={olsWindowMins}
+              onChange={(e) => setOlsWindowMins(Number(e.target.value))}
+              className={inputClass}
+            />
+          </Field>
+          <Field label="Recalc Every N Bars">
+            <input
+              type="number"
+              step="1"
+              min="1"
+              max="60"
+              value={olsRecalcIntervalBars}
+              onChange={(e) => setOlsRecalcIntervalBars(Number(e.target.value))}
+              className={inputClass}
+            />
+          </Field>
+        </div>
+      )}
 
       <button
         type="submit"

--- a/frontend/types/strategy.ts
+++ b/frontend/types/strategy.ts
@@ -48,4 +48,6 @@ export interface PairsStrategyConfig {
   minObservations: number;
   tradeNotionalUsd: number;
   priceSource: "mid" | "last_trade";
+  olsWindowMs: number;
+  olsRecalcIntervalBars: number;
 }


### PR DESCRIPTION
# Recent Changes

## `cce595c` — DI Wiring: Connect API and Runtime Layer

**Problem:** The Express HTTP layer and the trading engine were completely disconnected. Each runtime (`live.ts`, `replay.ts`) created its own `Orchestrator`, `EventBus`, and `SymbolStateManager`, but `createApp()` was a pure factory with no reference to those instances. Controllers had no path to the live engine and returned `501 Not Implemented` or empty stubs.

**What changed:**

- **`backend/src/app/context.ts`** _(new)_ — Defines the `AppContext` interface, the typed bridge between the runtime and the API layer:
  ```ts
  interface AppContext {
    orchestrator?: Orchestrator;
    symbolState?: SymbolStateManager;
    replayEngine?: ReplayEngine;
  }
  ```

- **`backend/src/app/index.ts`** — `createApp()` now accepts an optional `AppContext` and stores it on `app.locals.ctx`, making it available to all controllers via `req.app.locals.ctx`.

- **`backend/src/runtime/live.ts`** — Passes `{ orchestrator, symbolState }` into `createApp()`, connecting the live engine to the HTTP layer.

- **`backend/src/runtime/replay.ts`** — Passes `{ replayEngine }` into `createApp()`, removing the long-standing TODO comment.

- **`marketDataController.ts`** — `GET /api/market-data/symbols` now returns real tracked symbols from `SymbolStateManager.getSymbols()`. `GET /api/market-data/snapshot/:symbol` returns the live symbol state or 404 if not tracked.

- **`replayController.ts`** — `POST /api/replay/control` now forwards commands to the live `ReplayEngine`. `GET /api/replay/status` now returns the active session state.

- **`strategiesController.ts`** — `POST /api/strategies/:id/stop` now calls `orchestrator.deregisterStrategy(id)` on the live engine. `POST /api/strategies/start` now validates orchestrator presence (previously failed silently).

---

## `42fc1a8` — OLS Rolling Window Hedge Ratio for Pairs Strategy

**Problem:** The pairs strategy used a fixed, user-supplied hedge ratio (defaulting to `1.0`). This is inaccurate for real pairs because the cointegration ratio drifts over time. The strategy needed a data-driven hedge ratio that recalculates from recent price history.

**What changed:**

- **`backend/src/services/indicators/ols.ts`** _(new)_ — Implements Ordinary Least Squares regression. `computeOLSHedgeRatio(price1s, price2s)` regresses leg1 prices on leg2 prices and returns `{ beta, alpha, rSquared }`. `beta` is used as the hedge ratio. Returns `null` if there is insufficient data or if leg2 has zero variance.

- **`backend/src/services/indicators/index.ts`** — Exports the new OLS indicator.

- **`backend/src/strategies/pairs/pairsTypes.ts`** — Added internal state fields for OLS rolling windows (`olsLeg1Window`, `olsLeg2Window`) and a bar counter for throttling recalculation.

- **`backend/src/strategies/pairs/pairsConfig.ts`** — Added two new config fields:
  - `olsWindowMs` (default `14_400_000` — 4-hour window): controls how far back price history goes for each OLS fit.
  - `olsRecalcIntervalBars` (default `5`): how many bars between recalculations to avoid per-tick overhead.

- **`backend/src/strategies/pairs/pairsStrategy.ts`** — The strategy now pushes each new price into its OLS rolling windows and recomputes the hedge ratio every `olsRecalcIntervalBars` bars when `hedgeRatioMethod` is set to `"ols"`. Falls back to `fixedHedgeRatio` when insufficient history exists or when using `"fixed"` mode.

- **`frontend/features/strategy/StrategyForm.tsx`** and **`frontend/types/strategy.ts`** — The strategy configuration form exposes the new `olsWindowMs` and `olsRecalcIntervalBars` fields so they can be set from the UI.

---

## Remaining TODOs

### API Layer

| Location | Description |
|---|---|
| `strategiesController.ts` | `POST /api/strategies/start` returns `501` — needs a **strategy factory/registry** to instantiate an `IStrategy` from a JSON `{ strategyType, config }` payload before calling `orchestrator.registerStrategy()` |
| `replayController.ts` | `POST /api/replay/load` returns `501` — needs an **`event_logs` Supabase repository function** to fetch a recorded event log by ID and construct a `ReplaySession` |
| `replayController.ts` | `GET /api/replay/sessions` returns `[]` — same dependency on the `event_logs` table |

### Strategies

| Location | Description |
|---|---|
| `strategies/arbitrage/` | `ArbitrageStrategy`, `createArbitrageConfig()`, and `ArbitrageStrategyConfig` are not yet implemented |
| `strategies/momentum/` | `MomentumStrategy`, `createMomentumConfig()`, and `MomentumStrategyConfig` are not yet implemented |
| `strategies/marketMaking/` | `MarketMakingStrategy`, `createMarketMakingConfig()`, and `AvellanedaStoikovParams` are not yet implemented |
