### PR TITLE
Feat(backtest): improve speed by SSE streaming bars for the equity curve and removing the need for large database fetch at the end 

### DIFF
--- a/backend/src/app/controllers/backtestController.ts
+++ b/backend/src/app/controllers/backtestController.ts
@@ -21,9 +21,31 @@ import {
 import { BacktestEngine } from "../../core/backtest/backtestEngine";
 import { PairsStrategy } from "../../strategies/pairs/pairsStrategy";
 import { createPairsConfig } from "../../strategies/pairs/pairsConfig";
+import { backtestStreamManager } from "../../core/backtest/backtestStreamManager";
 import { logger } from "../../utils/logger";
 import { newId } from "../../utils/ids";
-import type { BacktestConfig } from "../../types/backtest";
+import type { BacktestConfig, BacktestResult } from "../../types/backtest";
+
+// In-memory cache so GET /api/backtests/:id is served instantly for a run that just
+// completed, without a DB round trip. Entries expire after 10 minutes.
+const CACHE_TTL_MS = 10 * 60 * 1000;
+const resultCache = new Map<string, { result: BacktestResult; expiresAt: number }>();
+
+function cacheResult(result: BacktestResult): void {
+  if (!result?.id) return;
+  // Strip orders and fills before caching — they can be hundreds of thousands of
+  // objects for long backtests. The DB row (backtest_results) omits them too, and
+  // the frontend only needs metrics + equity_curve from the initial result load.
+  const { orders: _o, fills: _f, ...slim } = result;
+  resultCache.set(result.id, { result: slim as BacktestResult, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+function getCached(id: string): BacktestResult | null {
+  const entry = resultCache.get(id);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) { resultCache.delete(id); return null; }
+  return entry.result;
+}
 
 /**
  * GET /api/backtests
@@ -50,6 +72,9 @@ export async function listBacktests(_req: Request, res: Response): Promise<void>
 export async function getBacktest(req: Request, res: Response): Promise<void> {
   const id = req.params.id as string;
   try {
+    const cached = getCached(id);
+    if (cached) { res.json(cached); return; }
+
     const result = await getBacktestResultById(id);
     if (!result) {
       res.status(404).json({ error: `Backtest ${id} not found` });
@@ -60,6 +85,24 @@ export async function getBacktest(req: Request, res: Response): Promise<void> {
     logger.error("getBacktest error", { id, err });
     res.status(500).json({ error: "Failed to fetch backtest" });
   }
+}
+
+/**
+ * GET /api/backtests/:id/stream
+ * SSE endpoint that streams live progress events for an in-progress backtest run.
+ * Connects to the run's EventEmitter channel and forwards progress/complete/error
+ * events as Server-Sent Events. Returns 404 if the run is not active.
+ * @param req - Express Request with params.id
+ * @param res - Express Response opened as text/event-stream
+ */
+export function streamBacktest(req: Request, res: Response): void {
+  const id = req.params.id as string;
+  const cleanup = backtestStreamManager.subscribe(id, res);
+  if (!cleanup) {
+    res.status(404).json({ error: `No active stream for backtest ${id}` });
+    return;
+  }
+  req.on("close", cleanup);
 }
 
 /**
@@ -86,6 +129,10 @@ export async function runBacktest(req: Request, res: Response): Promise<void> {
     dataGranularity: body.dataGranularity ?? "bar",
   };
 
+  // Register the SSE channel before sending 202 to avoid a race where the
+  // client subscribes before the channel exists
+  backtestStreamManager.register(config.id);
+
   // Acknowledge the request immediately; backtest runs in background
   res.status(202).json({ backtestId: config.id, message: "Backtest queued" });
 
@@ -94,25 +141,33 @@ export async function runBacktest(req: Request, res: Response): Promise<void> {
     const engine = new BacktestEngine();
     let resultInserted = false;
     try {
-      const result = await engine.run(config, () => {
-        // Factory creates the strategy specified in the config
-        if (config.strategyConfig.type === "pairs_trading") {
-          const pairsConfig = createPairsConfig(
-            config.strategyConfig.symbols[0],
-            config.strategyConfig.symbols[1] ?? config.strategyConfig.symbols[0],
-            config.strategyConfig as never,
-          );
-          return [new PairsStrategy(pairsConfig)];
-        }
-        return [];
-      });
+      const result = await engine.run(
+        config,
+        () => {
+          // Factory creates the strategy specified in the config
+          if (config.strategyConfig.type === "pairs_trading") {
+            const pairsConfig = createPairsConfig(
+              config.strategyConfig.symbols[0],
+              config.strategyConfig.symbols[1] ?? config.strategyConfig.symbols[0],
+              config.strategyConfig as never,
+            );
+            return [new PairsStrategy(pairsConfig)];
+          }
+          return [];
+        },
+        (point) => backtestStreamManager.emit(config.id, point),
+      );
+      cacheResult(result);
+      backtestStreamManager.complete(config.id);
       await insertBacktestResult(result);
       resultInserted = true;
+      // Orders must complete before fills: backtest_fills.order_id FK references backtest_orders.id
       await insertBacktestOrders(result.id, result.orders);
       await insertBacktestFills(result.id, result.fills);
       logger.info("Backtest completed and saved", { id: config.id });
     } catch (err) {
       logger.error("Backtest failed", { id: config.id, err });
+      backtestStreamManager.error(config.id, err instanceof Error ? err.message : "Backtest failed");
       if (resultInserted) {
         try { await updateBacktestResultStatus(config.id, "failed"); } catch {}
       }

--- a/backend/src/app/middleware/requestLogger.ts
+++ b/backend/src/app/middleware/requestLogger.ts
@@ -16,12 +16,15 @@ import { logger } from "../../utils/logger";
  */
 export function requestLogger(req: Request, res: Response, next: NextFunction): void {
   const start = Date.now();
+  // Snapshot before Express mutates req.url as the request descends into sub-routers.
+  // req.path would show only the sub-router-relative suffix by the time 'finish' fires.
+  const path = req.originalUrl.split("?")[0];
 
   res.on("finish", () => {
     const durationMs = Date.now() - start;
     logger.info("HTTP", {
       method: req.method,
-      path: req.path,
+      path,
       status: res.statusCode,
       durationMs,
     });

--- a/backend/src/app/routes/backtestRoutes.ts
+++ b/backend/src/app/routes/backtestRoutes.ts
@@ -10,12 +10,16 @@ import {
   listBacktests,
   getBacktest,
   runBacktest,
+  streamBacktest,
 } from "../controllers/backtestController";
 
 const router = Router();
 
 /** GET /api/backtests — list all backtest result summaries */
 router.get("/", listBacktests);
+
+/** GET /api/backtests/:id/stream — SSE stream of live progress events for an active run */
+router.get("/:id/stream", streamBacktest);
 
 /** GET /api/backtests/:id — get full backtest result with equity curve */
 router.get("/:id", getBacktest);

--- a/backend/src/core/backtest/backtestEngine.ts
+++ b/backend/src/core/backtest/backtestEngine.ts
@@ -30,6 +30,7 @@ import type { BacktestConfig, BacktestResult } from "../../types/backtest";
 import type { PortfolioSnapshot } from "../../types/portfolio";
 import type { IStrategy } from "../../strategies/base/strategy";
 import type { Fill } from "../../types/orders";
+import type { BacktestProgressPoint } from "./backtestStreamManager";
 
 export class BacktestEngine {
   private readonly loader = new BacktestLoader();
@@ -51,6 +52,7 @@ export class BacktestEngine {
       orderState: OrderStateManager;
       eventBus: EventBus;
     }) => IStrategy[],
+    onProgress?: (point: BacktestProgressPoint) => void,
   ): Promise<BacktestResult> {
     const startedAt = nowMs();
     logger.info("BacktestEngine: starting", { id: config.id, name: config.name });
@@ -98,6 +100,9 @@ export class BacktestEngine {
     orchestrator.start();
 
     const realDateNow = Date.now;
+    const totalBars = bars.length;
+    // Sample at most 5000 equity curve points to prevent OOM on long backtests
+    const sampleEvery = Math.max(1, Math.floor(totalBars / 5000));
 
     try {
       // OVERRIDE: Simulate wall-clock time for the duration of the backtest loop.
@@ -105,6 +110,7 @@ export class BacktestEngine {
       // correctly advance with simulated bar time rather than collapsing all historical bars
       // into a single wall-clock millisecond.
       // TODO: Future refactor should remove this and inject a deterministic clock via `EvaluationContext`.
+      let barIndex = 0;
       for (const bar of bars) {
         Date.now = () => bar.ts;
         eventBus.publish({
@@ -116,8 +122,12 @@ export class BacktestEngine {
           payload: bar,
         });
 
-        // Take a portfolio snapshot after each bar for the equity curve
-        equityCurve.push(portfolioState.getSnapshot());
+        if (barIndex % sampleEvery === 0) {
+          const snap = portfolioState.getSnapshot();
+          equityCurve.push(snap);
+          onProgress?.({ ts: bar.ts, equity: snap.equity, barIndex, totalBars });
+        }
+        barIndex++;
       }
     } finally {
       // Guarantee restoration even if an error is thrown

--- a/backend/src/core/backtest/backtestStreamManager.ts
+++ b/backend/src/core/backtest/backtestStreamManager.ts
@@ -1,0 +1,109 @@
+/**
+ * core/backtest/backtestStreamManager.ts
+ *
+ * Bridges the background backtest simulation with SSE clients.
+ * One EventEmitter per run is created when the run starts and torn down
+ * shortly after it completes or errors. Multiple SSE connections (browser
+ * tabs, dev tools) can subscribe to the same run concurrently.
+ *
+ * Inputs:  progress points emitted by BacktestEngine during simulation.
+ * Outputs: SSE events forwarded to connected Express Response streams.
+ */
+
+import { EventEmitter } from "events";
+import type { Response } from "express";
+
+export interface BacktestProgressPoint {
+  /** Simulated bar timestamp (Unix ms) */
+  ts: number;
+  /** Portfolio equity at this point */
+  equity: number;
+  /** Bars processed so far */
+  barIndex: number;
+  /** Total bars in the run */
+  totalBars: number;
+}
+
+class BacktestStreamManager {
+  private channels = new Map<string, EventEmitter>();
+
+  /** Create a channel for a new run. Must be called before setImmediate fires. */
+  register(id: string): void {
+    if (!this.channels.has(id)) {
+      const emitter = new EventEmitter();
+      emitter.setMaxListeners(50); // allow many concurrent SSE subscribers
+      this.channels.set(id, emitter);
+    }
+  }
+
+  /** Returns true if a run channel is currently active. */
+  has(id: string): boolean {
+    return this.channels.has(id);
+  }
+
+  /** Emit a progress point to all subscribed SSE clients. */
+  emit(id: string, point: BacktestProgressPoint): void {
+    this.channels.get(id)?.emit("progress", point);
+  }
+
+  /** Signal successful completion. Channel is removed after a grace period. */
+  complete(id: string): void {
+    const emitter = this.channels.get(id);
+    if (!emitter) return;
+    emitter.emit("complete");
+    setTimeout(() => this.channels.delete(id), 10_000).unref();
+  }
+
+  /** Signal a run failure. Channel is removed after a grace period. */
+  error(id: string, message: string): void {
+    const emitter = this.channels.get(id);
+    if (!emitter) return;
+    emitter.emit("run-error", message);
+    setTimeout(() => this.channels.delete(id), 10_000).unref();
+  }
+
+  /**
+   * Attach an SSE Response to this run's channel.
+   * Sets headers, begins streaming, and returns a cleanup function to call
+   * when the client disconnects.
+   *
+   * Returns null if no channel exists for the given id.
+   */
+  subscribe(id: string, res: Response): (() => void) | null {
+    const emitter = this.channels.get(id);
+    if (!emitter) return null;
+
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache");
+    res.setHeader("Connection", "keep-alive");
+    // Disable proxy/nginx buffering so events arrive immediately
+    res.setHeader("X-Accel-Buffering", "no");
+    res.flushHeaders();
+
+    const onProgress = (point: BacktestProgressPoint) => {
+      res.write(`event: progress\ndata: ${JSON.stringify(point)}\n\n`);
+    };
+
+    const onComplete = () => {
+      res.write(`event: complete\ndata: {}\n\n`);
+      res.end();
+    };
+
+    const onError = (message: string) => {
+      res.write(`event: error\ndata: ${JSON.stringify({ message })}\n\n`);
+      res.end();
+    };
+
+    emitter.on("progress", onProgress);
+    emitter.once("complete", onComplete);
+    emitter.once("run-error", onError);
+
+    return () => {
+      emitter.off("progress", onProgress);
+      emitter.off("complete", onComplete);
+      emitter.off("run-error", onError);
+    };
+  }
+}
+
+export const backtestStreamManager = new BacktestStreamManager();

--- a/frontend/app/backtest/page.tsx
+++ b/frontend/app/backtest/page.tsx
@@ -5,7 +5,7 @@
  * Allows users to configure and run a backtest, then view the resulting metrics,
  * equity curve, and trade log.
  *
- * Data:    useBacktest hook for run state, submit action, and result data.
+ * Data:    useBacktest hook for run state, SSE progress, and result data.
  * Layout:  Top = BacktestForm, Bottom = BacktestResults (shown after run completes).
  */
 
@@ -14,31 +14,12 @@
 import BacktestForm from "../../features/backtest/BacktestForm";
 import BacktestResults from "../../features/backtest/BacktestResults";
 import { useBacktest } from "../../hooks/useBacktest";
-import { fetchBacktest } from "../../services/backtestService";
 
 export default function BacktestPage() {
-  const { selectedResult, isRunning, error, run, loadResult } = useBacktest();
+  const { selectedResult, isRunning, progress, error, run } = useBacktest();
 
   const handleRun = async (config: Parameters<typeof run>[0]) => {
-    const id = await run(config);
-    // The backtest runs asynchronously on the backend. Poll until it appears
-    // in the DB (status: completed or failed), then use the already-fetched
-    // result directly to avoid a redundant round trip.
-    const POLL_INTERVAL_MS = 500;
-    const POLL_TIMEOUT_MS = 120_000;
-    const deadline = Date.now() + POLL_TIMEOUT_MS;
-    while (Date.now() < deadline) {
-      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
-      try {
-        const current = await fetchBacktest(id);
-        if (current.status === "completed" || current.status === "failed") {
-          await loadResult(id, current);
-          break;
-        }
-      } catch {
-        // result not in DB yet — keep polling
-      }
-    }
+    await run(config);
   };
 
   return (
@@ -64,8 +45,24 @@ export default function BacktestPage() {
               {error}
             </div>
           )}
-          {isRunning && (
-            <p className="text-sm text-zinc-400">Running backtest…</p>
+          {isRunning && !progress && (
+            <p className="text-sm text-zinc-400">Connecting…</p>
+          )}
+          {isRunning && progress && (
+            <div className="space-y-2">
+              <div className="flex items-center justify-between text-sm text-zinc-400">
+                <span>Running backtest…</span>
+                <span>
+                  {progress.pct}% — {progress.barIndex.toLocaleString()} / {progress.totalBars.toLocaleString()} bars
+                </span>
+              </div>
+              <div className="h-1.5 rounded-full bg-zinc-200 dark:bg-zinc-700">
+                <div
+                  className="h-1.5 rounded-full bg-blue-500 transition-all duration-300"
+                  style={{ width: `${progress.pct}%` }}
+                />
+              </div>
+            </div>
           )}
           {!isRunning && selectedResult && <BacktestResults result={selectedResult} />}
           {!isRunning && !selectedResult && !error && (

--- a/frontend/app/backtest/page.tsx
+++ b/frontend/app/backtest/page.tsx
@@ -22,8 +22,9 @@ export default function BacktestPage() {
   const handleRun = async (config: Parameters<typeof run>[0]) => {
     const id = await run(config);
     // The backtest runs asynchronously on the backend. Poll until it appears
-    // in the DB (status: completed or failed), then load the full result.
-    const POLL_INTERVAL_MS = 2_000;
+    // in the DB (status: completed or failed), then use the already-fetched
+    // result directly to avoid a redundant round trip.
+    const POLL_INTERVAL_MS = 500;
     const POLL_TIMEOUT_MS = 120_000;
     const deadline = Date.now() + POLL_TIMEOUT_MS;
     while (Date.now() < deadline) {
@@ -31,7 +32,7 @@ export default function BacktestPage() {
       try {
         const current = await fetchBacktest(id);
         if (current.status === "completed" || current.status === "failed") {
-          await loadResult(id);
+          await loadResult(id, current);
           break;
         }
       } catch {

--- a/frontend/hooks/useBacktest.ts
+++ b/frontend/hooks/useBacktest.ts
@@ -20,7 +20,7 @@ interface UseBacktestResult {
   isRunning: boolean;
   error: string | null;
   run: (config: Omit<BacktestConfig, "id">) => Promise<string>;
-  loadResult: (id: string) => Promise<void>;
+  loadResult: (id: string, prefetched?: BacktestResult) => Promise<void>;
   refetch: () => void;
 }
 
@@ -60,8 +60,8 @@ export function useBacktest(): UseBacktestResult {
     }
   }, [fetchData]);
 
-  const loadResult = useCallback(async (id: string) => {
-    const result = await fetchBacktest(id);
+  const loadResult = useCallback(async (id: string, prefetched?: BacktestResult) => {
+    const result = prefetched ?? await fetchBacktest(id);
     setSelectedResult(result);
   }, []);
 

--- a/frontend/hooks/useBacktest.ts
+++ b/frontend/hooks/useBacktest.ts
@@ -4,20 +4,28 @@
  * Custom React hook for managing backtest runs and results.
  *
  * Inputs:  BacktestConfig for new runs; optional backtest ID to load.
- * Outputs: { results, selectedResult, isRunning, run, loadResult, error }
+ * Outputs: { results, selectedResult, isRunning, progress, run, loadResult, error }
  */
 
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { fetchBacktests, fetchBacktest, runBacktest } from "../services/backtestService";
+import { config as appConfig } from "../config";
 import type { BacktestConfig, BacktestResult } from "../types/api";
+
+interface BacktestProgress {
+  barIndex: number;
+  totalBars: number;
+  pct: number;
+}
 
 interface UseBacktestResult {
   results: BacktestResult[];
   selectedResult: BacktestResult | null;
   isLoading: boolean;
   isRunning: boolean;
+  progress: BacktestProgress | null;
   error: string | null;
   run: (config: Omit<BacktestConfig, "id">) => Promise<string>;
   loadResult: (id: string, prefetched?: BacktestResult) => Promise<void>;
@@ -33,7 +41,9 @@ export function useBacktest(): UseBacktestResult {
   const [selectedResult, setSelectedResult] = useState<BacktestResult | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isRunning, setIsRunning] = useState(false);
+  const [progress, setProgress] = useState<BacktestProgress | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const esRef = useRef<EventSource | null>(null);
 
   const fetchData = useCallback(async () => {
     try {
@@ -49,14 +59,55 @@ export function useBacktest(): UseBacktestResult {
 
   useEffect(() => { fetchData(); }, [fetchData]);
 
+  // Close any open SSE connection when the component unmounts
+  useEffect(() => () => { esRef.current?.close(); }, []);
+
   const run = useCallback(async (config: Omit<BacktestConfig, "id">): Promise<string> => {
     setIsRunning(true);
+    setProgress(null);
+    setError(null);
     try {
       const { backtestId } = await runBacktest(config);
       await fetchData();
+
+      // Open SSE stream for real-time progress.
+      // appConfig.apiBaseUrl (e.g. http://localhost:8080/api) + path = full endpoint URL.
+      // isRunning stays true here — the SSE handlers below own the transition to false.
+      const es = new EventSource(`${appConfig.apiBaseUrl}/backtests/${backtestId}/stream`);
+      esRef.current = es;
+
+      es.addEventListener("progress", (e: MessageEvent) => {
+        const { barIndex, totalBars } = JSON.parse(e.data as string) as { barIndex: number; totalBars: number };
+        setProgress({ barIndex, totalBars, pct: Math.round((barIndex / totalBars) * 100) });
+      });
+
+      es.addEventListener("complete", () => {
+        es.close();
+        esRef.current = null;
+        // Result is in the backend in-memory cache — single fetch, no polling needed
+        fetchBacktest(backtestId)
+          .then((result) => { setSelectedResult(result); return fetchData(); })
+          .catch((err) => { setError(err instanceof Error ? err.message : "Failed to load result"); })
+          .finally(() => { setIsRunning(false); setProgress(null); });
+      });
+
+      es.addEventListener("error", (e: Event) => {
+        es.close();
+        esRef.current = null;
+        let msg = "Backtest failed";
+        if (e instanceof MessageEvent && e.data) {
+          try { msg = (JSON.parse(e.data as string) as { message: string }).message; } catch {}
+        }
+        setError(msg);
+        setIsRunning(false);
+        setProgress(null);
+      });
+
       return backtestId;
-    } finally {
+    } catch (err) {
       setIsRunning(false);
+      setProgress(null);
+      throw err;
     }
   }, [fetchData]);
 
@@ -65,5 +116,5 @@ export function useBacktest(): UseBacktestResult {
     setSelectedResult(result);
   }, []);
 
-  return { results, selectedResult, isLoading, isRunning, error, run, loadResult, refetch: fetchData };
+  return { results, selectedResult, isLoading, isRunning, progress, error, run, loadResult, refetch: fetchData };
 }


### PR DESCRIPTION
# Backtest Streaming & Reliability Improvements

## Summary

- **Commit 1** builds a complete SSE streaming layer on the backend — equity-curve sampling to prevent OOM on long runs, a per-run EventEmitter channel bridging the simulation to HTTP clients, and a new `GET /api/backtests/:id/stream` endpoint
- **Commit 2** replaces the fragile 120-second polling loop in the frontend with an `EventSource` connection to that stream, keeping `isRunning` accurate and showing a live progress bar for the duration of the run

---

## Commit 1 — Backend streaming infrastructure + polling optimizations

### Problem
Multi-year backtests (e.g. 10-year, 1-min bars ≈ 1.97 M bars) caused a Node.js heap OOM because the engine pushed a full `PortfolioSnapshot` object on every single bar. Unrelated to OOM, the HTTP request logger was logging truncated paths (e.g. `/<uuid>` instead of `/api/backtests/<uuid>`) because it read `req.path` inside a `res.on('finish')` callback — by which point Express had already stripped the router mount prefixes from `req.url`.

### Changes

**`backtestEngine.ts`**
- Equity curve sampling: `sampleEvery = Math.max(1, Math.floor(totalBars / 5000))` bounds the curve to ≤ 5001 entries regardless of run length, eliminating the OOM
- Added optional `onProgress` third parameter — called at each sample point with `{ ts, equity, barIndex, totalBars }`

**`backtestStreamManager.ts`** *(new file)*
- Singleton `BacktestStreamManager` that holds one `EventEmitter` per active run
- `register(id)` — called before the 202 response to avoid a subscribe race
- `emit(id, point)` — fans out progress points to all connected SSE clients
- `complete(id)` / `error(id, message)` — signal run outcome, then remove the channel after a 10-second grace period (`.unref()` so the timer does not block Jest worker exit)
- `subscribe(id, res)` — sets SSE headers (`Content-Type: text/event-stream`, `X-Accel-Buffering: no`), flushes headers, attaches listeners, returns a cleanup function for client disconnect

**`backtestController.ts`**
- Added `streamBacktest` handler: calls `backtestStreamManager.subscribe`, wires `req.on('close', cleanup)`
- `runBacktest`: registers the SSE channel before sending 202, passes the `onProgress` callback to `engine.run`, calls `complete`/`error` after the simulation finishes
- Added a 10-minute in-memory result cache (orders/fills stripped before caching to avoid accumulation) so `GET /api/backtests/:id` is served instantly after a run without a DB round trip

**`backtestRoutes.ts`**
- `GET /:id/stream` registered before `GET /:id` to avoid path ambiguity

**`requestLogger.ts`**
- Snapshots `req.originalUrl` at middleware entry time; `req.path` is derived from `req.url`, which Express mutates as requests descend into sub-routers, so it was stale by the time `res.on('finish')` fired

**`useBacktest.ts` / `page.tsx`** *(minor, part of this commit)*
- Poll interval tightened from 2 s → 500 ms
- `loadResult` accepts an optional `prefetched` result to eliminate a redundant `GET` at the end of each successful poll

---

## Commit 2 — Frontend SSE consumer + progress bar

### Problem
`useBacktest.run()` set `isRunning = false` in its `finally` block as soon as the 202 response arrived — before the actual computation finished. The page then polled with a 120-second timeout, which expired for any backtest longer than ~2 minutes (10-year runs take 3–15 min). The result never loaded and the UI silently reset to the empty "Configure a backtest" state.

### Changes

**`useBacktest.ts`**
- Added `progress: { barIndex, totalBars, pct } | null` state
- Added `esRef = useRef<EventSource>` + unmount effect to close the stream if the component is destroyed mid-run
- `run()` no longer sets `isRunning = false` in `finally` — the SSE handlers own that transition:
  - `progress` event → updates `progress` state
  - `complete` event → closes the stream, performs a single cache-hit fetch, then transitions to idle
  - `error` event → differentiates between backend-sent `MessageEvent` failures and raw connection drops, surfaces the message, transitions to idle
- Returns `backtestId` immediately after opening the `EventSource`; the hook's reactive state drives the UI

**`page.tsx`**
- Removed the 120-second polling loop and the direct `fetchBacktest` import
- `handleRun` is now two lines
- "Connecting…" shown while the SSE handshake completes (before the first `progress` event)
- Animated progress bar with live bar count and percentage once events start arriving

---

## Test plan

- [x] Run a short backtest (1 year) — progress bar appears, fills to 100%, result loads on `complete`
- [x] Run a long backtest (10 years) — does not time out; bar count advances in real time, result loads on completion
- [x] Navigate away mid-run — backend continues to completion; no server errors; SSE connection closed cleanly
- [x] Kill the backend mid-run — `onerror` fires on the `EventSource`; UI shows an error message
- [x] `npx tsc --noEmit` in `frontend/` — zero errors in modified files
- [x] `npm test` in `backend/` — all 417 tests pass
