### PR TITLE
feat(backtest): reuse backtest result if found, fix querying extra columns to speed up lookup

### DIFF
--- a/backend/src/adapters/supabase/repositories.ts
+++ b/backend/src/adapters/supabase/repositories.ts
@@ -277,17 +277,34 @@ export async function deleteStrategy(id: UUID): Promise<void> {
 // Backtest Results
 // ------------------------------------------------------------------
 
+// Runs `tasks` with at most `concurrency` in-flight at a time.
+// Rejects immediately if any task throws, mirroring Promise.all behaviour.
+async function runConcurrent<T>(tasks: (() => Promise<T>)[], concurrency: number): Promise<T[]> {
+  const results: T[] = [];
+  let index = 0;
+  async function worker(): Promise<void> {
+    while (index < tasks.length) {
+      const i = index++;
+      results[i] = await tasks[i]();
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, tasks.length) }, worker));
+  return results;
+}
+
+const CHUNK_SIZE = 1000;
+const CHUNK_CONCURRENCY = 4;
+
 export async function insertBacktestOrders(backtestId: string, orders: Order[]): Promise<void> {
   if (!orders || orders.length === 0) {
     logger.info("insertBacktestOrders: no orders to insert", { backtestId });
     return;
   }
   const supabase = getSupabaseClient();
-  const CHUNK_SIZE = 1000;
 
+  const chunks: object[][] = [];
   for (let i = 0; i < orders.length; i += CHUNK_SIZE) {
-    const chunk = orders.slice(i, i + CHUNK_SIZE);
-    const payload = chunk.map(o => ({
+    chunks.push(orders.slice(i, i + CHUNK_SIZE).map(o => ({
       id:             o.id,
       backtest_id:    backtestId,
       strategy_id:    o.strategyId,
@@ -302,22 +319,18 @@ export async function insertBacktestOrders(backtestId: string, orders: Order[]):
       status:         o.status,
       submitted_at:   new Date(o.submittedAt).toISOString(),
       closed_at:      o.closedAt ? new Date(o.closedAt).toISOString() : null,
-    }));
+    })));
+  }
 
+  await runConcurrent(chunks.map((payload, idx) => async () => {
     const { error } = await supabase.from("backtest_orders").insert(payload);
     if (error) {
       let msg = error.message || "Unknown error";
-      if (msg.startsWith("<!DOCTYPE") || msg.startsWith("<html")) {
-        msg = `HTML response (Cloudflare/5xx) - length: ${msg.length}`;
-      }
-      logger.error("insertBacktestOrders failed on chunk", {
-        error: { ...error, message: msg },
-        backtestId,
-        chunkIndex: i,
-      });
+      if (msg.startsWith("<!DOCTYPE") || msg.startsWith("<html")) msg = `HTML response (Cloudflare/5xx) - length: ${msg.length}`;
+      logger.error("insertBacktestOrders failed on chunk", { error: { ...error, message: msg }, backtestId, chunkIndex: idx });
       throw new Error(`Failed to insert backtest orders chunk: ${msg}`);
     }
-  }
+  }), CHUNK_CONCURRENCY);
 }
 
 export async function insertBacktestFills(backtestId: string, fills: Fill[]): Promise<void> {
@@ -326,11 +339,10 @@ export async function insertBacktestFills(backtestId: string, fills: Fill[]): Pr
     return;
   }
   const supabase = getSupabaseClient();
-  const CHUNK_SIZE = 1000;
 
+  const chunks: object[][] = [];
   for (let i = 0; i < fills.length; i += CHUNK_SIZE) {
-    const chunk = fills.slice(i, i + CHUNK_SIZE);
-    const payload = chunk.map(f => ({
+    chunks.push(fills.slice(i, i + CHUNK_SIZE).map(f => ({
       id:          f.id,
       backtest_id: backtestId,
       order_id:    f.orderId,
@@ -341,22 +353,18 @@ export async function insertBacktestFills(backtestId: string, fills: Fill[]): Pr
       notional:    f.notional,
       commission:  f.commission,
       ts:          f.isoTs || new Date(f.ts).toISOString(),
-    }));
+    })));
+  }
 
+  await runConcurrent(fills.length > 0 ? chunks.map((payload, idx) => async () => {
     const { error } = await supabase.from("backtest_fills").insert(payload);
     if (error) {
       let msg = error.message || "Unknown error";
-      if (msg.startsWith("<!DOCTYPE") || msg.startsWith("<html")) {
-        msg = `HTML response (Cloudflare/5xx) - length: ${msg.length}`;
-      }
-      logger.error("insertBacktestFills failed on chunk", {
-        error: { ...error, message: msg },
-        backtestId,
-        chunkIndex: i,
-      });
+      if (msg.startsWith("<!DOCTYPE") || msg.startsWith("<html")) msg = `HTML response (Cloudflare/5xx) - length: ${msg.length}`;
+      logger.error("insertBacktestFills failed on chunk", { error: { ...error, message: msg }, backtestId, chunkIndex: idx });
       throw new Error(`Failed to insert backtest fills chunk: ${msg}`);
     }
-  }
+  }) : [], CHUNK_CONCURRENCY);
 }
 
 // Not currently used — waiting for frontend wiring to replace the inline logic in insertBacktestResult.
@@ -444,13 +452,13 @@ export async function getAllBacktestResults(): Promise<BacktestResult[]> {
   const supabase = getSupabaseClient();
   const { data, error } = await supabase
     .from("backtest_results")
-    .select("*")
+    .select("id, strategy_id, strategy_version, config, status, started_at, completed_at, error_message, final_portfolio, metrics, event_count, created_at")
     .order("started_at", { ascending: false });
   if (error) {
     logger.error("getAllBacktestResults failed", { error: error.message });
     return [];
   }
-  return (data ?? []) as BacktestResult[];
+  return (data ?? []) as unknown as BacktestResult[];
 }
 
 /**

--- a/backend/src/adapters/supabase/repositories.ts
+++ b/backend/src/adapters/supabase/repositories.ts
@@ -14,7 +14,7 @@ import { logger } from "../../utils/logger";
 import type { Order, Fill } from "../../types/orders";
 import type { PortfolioSnapshot } from "../../types/portfolio";
 import type { StrategyRun, Strategy } from "../../types/strategy";
-import type { BacktestResult } from "../../types/backtest";
+import type { BacktestConfig, BacktestResult } from "../../types/backtest";
 import type { UUID } from "../../types/common";
 
 // ------------------------------------------------------------------
@@ -433,6 +433,62 @@ export async function insertBacktestResult(result: BacktestResult): Promise<void
     }
     logger.warn("insertBacktestResult: transient 5xx, will retry", { attempt, msg });
   }
+}
+
+// Recursively serializes an object with sorted keys so that two objects with the
+// same values but different insertion order produce the same string.
+function stableStringify(val: unknown): string {
+  if (val === null || typeof val !== "object") return JSON.stringify(val);
+  if (Array.isArray(val)) return `[${val.map(stableStringify).join(",")}]`;
+  const keys = Object.keys(val as Record<string, unknown>).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify((val as Record<string, unknown>)[k])}`).join(",")}}`;
+}
+
+// Returns a stable fingerprint over the fields that define a unique backtest run.
+// Excludes id, name, description, and meta since they don't affect the simulation.
+// Includes strategyVersion so results from outdated algorithm versions are not reused.
+function backtestConfigKey(config: BacktestConfig): string {
+  return stableStringify({
+    startDate: config.startDate,
+    endDate: config.endDate,
+    initialCapital: config.initialCapital,
+    slippageBps: config.slippageBps,
+    commissionPerShare: config.commissionPerShare,
+    dataGranularity: config.dataGranularity,
+    strategyVersion: config.strategyVersion ?? null,
+    strategyConfig: config.strategyConfig,
+  });
+}
+
+/**
+ * Searches completed backtest results for one whose config fingerprint matches
+ * the supplied config. Filters by strategy_version in the DB query when available
+ * so outdated algorithm versions are never reused. Returns the full result
+ * (including equity_curve) if a match is found, otherwise null.
+ */
+export async function findMatchingBacktestResult(config: BacktestConfig): Promise<BacktestResult | null> {
+  const supabase = getSupabaseClient();
+  let query = supabase
+    .from("backtest_results")
+    .select("id, config, strategy_version, started_at, completed_at")
+    .eq("status", "completed")
+    .order("started_at", { ascending: false })
+    .limit(50);
+
+  // Filter by strategy_version at the DB level when it is known, so rows from
+  // other algorithm versions are excluded before any JS comparison.
+  if (config.strategyVersion != null) {
+    query = query.eq("strategy_version", config.strategyVersion);
+  }
+
+  const { data, error } = await query;
+  if (error || !data || data.length === 0) return null;
+
+  const key = backtestConfigKey(config);
+  const match = data.find((row) => backtestConfigKey(row.config as BacktestConfig) === key);
+  if (!match) return null;
+
+  return getBacktestResultById(match.id as string);
 }
 
 export async function updateBacktestResultStatus(id: string, status: string): Promise<void> {

--- a/backend/src/app/controllers/backtestController.ts
+++ b/backend/src/app/controllers/backtestController.ts
@@ -13,6 +13,7 @@ import type { Request, Response } from "express";
 import {
   getAllBacktestResults,
   getBacktestResultById,
+  findMatchingBacktestResult,
   insertBacktestResult,
   insertBacktestOrders,
   insertBacktestFills,
@@ -138,6 +139,16 @@ export async function runBacktest(req: Request, res: Response): Promise<void> {
 
   // Run backtest asynchronously
   setImmediate(async () => {
+    // Dedup: if an identical config has already been run, serve that result instead.
+    const existing = await findMatchingBacktestResult(config);
+    if (existing) {
+      const reused = { ...existing, id: config.id, reused_from_id: existing.id };
+      cacheResult(reused as typeof existing);
+      backtestStreamManager.complete(config.id);
+      logger.info("Backtest deduplicated", { id: config.id, reusedFromId: existing.id });
+      return;
+    }
+
     const engine = new BacktestEngine();
     let resultInserted = false;
     try {

--- a/backend/src/types/backtest.ts
+++ b/backend/src/types/backtest.ts
@@ -90,4 +90,9 @@ export interface BacktestResult {
   fills: Fill[];
   /** Number of events processed */
   event_count: number;
+  /**
+   * Set when this result was served from a previous identical run.
+   * Contains the original backtest_results.id that was reused.
+   */
+  reused_from_id?: string;
 }

--- a/frontend/features/backtest/BacktestResults.tsx
+++ b/frontend/features/backtest/BacktestResults.tsx
@@ -14,7 +14,7 @@ import PnLChart from "../../components/charts/PnLChart";
 import type { BacktestResult } from "../../types/api";
 import type { PortfolioSnapshot, PerformanceMetrics } from "../../types/portfolio";
 import { formatPercent, formatCurrency } from "../../utils/formatting";
-import { formatDuration } from "../../utils/dates";
+import { formatDuration, formatTimestamp } from "../../utils/dates";
 
 interface Props {
   result: BacktestResult;
@@ -23,11 +23,27 @@ interface Props {
 export default function BacktestResults({ result }: Props) {
   const metrics = result.metrics;
   const equityCurve = result.equity_curve ?? [];
+  const isReused = !!result.reused_from_id;
+  const duration =
+    result.completed_at && result.started_at
+      ? result.completed_at - result.started_at
+      : null;
+
+  const runMeta = isReused
+    ? `Reused from ${result.completed_at ? formatTimestamp(result.completed_at) : "previous run"}`
+    : result.completed_at
+      ? `Completed ${formatTimestamp(result.completed_at)}${duration ? ` · Ran in ${formatDuration(duration)}` : ""}`
+      : null;
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">{result.config.name}</h3>
+      <div className="flex items-start justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">{result.config.name}</h3>
+          {runMeta && (
+            <p className="mt-0.5 text-xs text-zinc-400 dark:text-zinc-500">{runMeta}</p>
+          )}
+        </div>
         <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${result.status === "completed" ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"}`}>
           {result.status}
         </span>

--- a/frontend/types/api.ts
+++ b/frontend/types/api.ts
@@ -64,6 +64,8 @@ export interface BacktestResult {
   metrics?: import("./portfolio").PerformanceMetrics;
   equity_curve?: import("./portfolio").PortfolioSnapshot[];
   event_count?: number;
+  /** Set when this result was served from a previous identical run. */
+  reused_from_id?: string;
 }
 
 export type ReplaySpeed = 0.25 | 0.5 | 1 | 2 | 5 | 10 | "step";


### PR DESCRIPTION
## Additional changes:
- Display time for calculation and how long it took to look up 

## Next steps: 
- Refactor the backtest search lookup into its own service to also use for looking through past backtest results from the client. Add the option to delete or re-run tests
- May be smart to save the time for calculation into the database and still display when reusing backtests